### PR TITLE
feat: Implement initial schedulers for Phase 2 (Strict Priority & WRR)

### DIFF
--- a/hqts/include/hqts/scheduler/packet_descriptor.h
+++ b/hqts/include/hqts/scheduler/packet_descriptor.h
@@ -1,0 +1,57 @@
+#ifndef HQTS_SCHEDULER_PACKET_DESCRIPTOR_H_
+#define HQTS_SCHEDULER_PACKET_DESCRIPTOR_H_
+
+#include "hqts/core/flow_context.h" // For hqts::core::FlowId
+
+#include <cstdint>
+#include <vector>
+#include <cstddef> // For std::byte (if C++17) or alternative
+
+// Ensure std::byte is available (C++17 and later)
+#if __cplusplus >= 201703L
+#include <cstddef> // For std::byte
+#else
+// Basic fallback for pre-C++17, not a perfect polyfill but enough for opaque data
+namespace std {
+enum class byte : unsigned char {};
+}
+#endif
+
+
+namespace hqts {
+namespace scheduler {
+
+struct PacketDescriptor {
+    core::FlowId flow_id;
+    uint32_t packet_length_bytes;
+    uint8_t priority; // Could be derived from flow's policy (e.g., DSCP, PCP)
+
+    // Optional: Represents the packet payload or a reference to it.
+    // For a descriptor, it might not store the full payload but metadata or a pointer.
+    // Using std::vector<std::byte> for an owned, opaque payload for simplicity here.
+    std::vector<std::byte> payload;
+
+    // Constructor
+    PacketDescriptor(core::FlowId f_id, uint32_t len, uint8_t prio, size_t actual_payload_to_copy_size = 0)
+        : flow_id(f_id), packet_length_bytes(len), priority(prio) {
+        if (actual_payload_to_copy_size > 0) {
+            // This constructor implies copying at least part of a payload if given.
+            // In a real system, payload might be a pointer/reference or handled differently.
+            // For now, we just resize to simulate holding some data.
+            payload.resize(actual_payload_to_copy_size);
+            // In a real scenario, one might do:
+            // if (source_payload_ptr && actual_payload_to_copy_size > 0) {
+            //    payload.assign(static_cast<const std::byte*>(source_payload_ptr),
+            //                   static_cast<const std::byte*>(source_payload_ptr) + actual_payload_to_copy_size);
+            // }
+        }
+    }
+
+    // Default constructor for cases where it might be needed
+    PacketDescriptor() = default;
+};
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_PACKET_DESCRIPTOR_H_

--- a/hqts/include/hqts/scheduler/queue_types.h
+++ b/hqts/include/hqts/scheduler/queue_types.h
@@ -1,0 +1,25 @@
+#ifndef HQTS_SCHEDULER_QUEUE_TYPES_H_
+#define HQTS_SCHEDULER_QUEUE_TYPES_H_
+
+#include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
+
+#include <queue>    // For std::queue
+#include <deque>    // std::queue is often implemented using std::deque by default
+#include <vector>   // Can also be used as std::queue's underlying container
+#include <list>     // Can also be used as std::queue's underlying container
+
+namespace hqts {
+namespace scheduler {
+
+// Basic packet queue type using std::queue with std::deque as the underlying container.
+// std::deque is generally a good default for std::queue.
+using PacketQueue = std::queue<PacketDescriptor>;
+
+// Alternative queue types could be defined here if needed, for example:
+// using PriorityPacketQueue = std::priority_queue<PacketDescriptor, std::vector<PacketDescriptor>, SomeComparator>;
+// using BoundedPacketQueue = ... (would require a custom bounded queue implementation)
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_QUEUE_TYPES_H_

--- a/hqts/include/hqts/scheduler/scheduler_interface.h
+++ b/hqts/include/hqts/scheduler/scheduler_interface.h
@@ -1,0 +1,86 @@
+#ifndef HQTS_SCHEDULER_SCHEDULER_INTERFACE_H_
+#define HQTS_SCHEDULER_SCHEDULER_INTERFACE_H_
+
+#include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
+#include "hqts/core/flow_context.h"          // For core::QueueId (though not used in current commented-out methods)
+
+#include <cstdint> // For uint32_t in commented-out methods
+
+namespace hqts {
+namespace scheduler {
+
+class SchedulerInterface {
+public:
+    virtual ~SchedulerInterface() = default;
+
+    /**
+     * @brief Enqueues a packet into the scheduler.
+     *
+     * The scheduler implementation will determine how and where this packet is stored
+     * based on its internal logic (e.g., flow ID, priority).
+     *
+     * @param packet The packet descriptor to enqueue.
+     */
+    virtual void enqueue(PacketDescriptor packet) = 0;
+
+    /**
+     * @brief Dequeues a packet from the scheduler according to its scheduling discipline.
+     *
+     * The returned packet is the one selected by the scheduler to be processed next.
+     * If the scheduler is empty and no packet can be dequeued, the behavior might
+     * depend on the implementation (e.g., throw an exception, or return a PacketDescriptor
+     * with a special state, though the latter is less common for dequeue).
+     * For simplicity, assume it blocks or throws if empty, or users check is_empty() first.
+     *
+     * @return PacketDescriptor The packet descriptor dequeued.
+     */
+    virtual PacketDescriptor dequeue() = 0;
+
+    /**
+     * @brief Checks if the scheduler is currently empty.
+     *
+     * An empty scheduler has no packets to dequeue.
+     *
+     * @return true if the scheduler has no packets, false otherwise.
+     */
+    virtual bool is_empty() const = 0;
+
+    /**
+     * @brief Gets the number of packets currently held by the scheduler.
+     * @return The total number of packets across all internal queues.
+     */
+    // virtual size_t size() const = 0; // Optional: total size
+
+    // --- Dynamic Queue Management Examples (Optional - depends on scheduler type) ---
+    // These methods might be relevant for schedulers that allow dynamic configuration
+    // of queues (e.g., for different traffic classes or policies).
+
+    /**
+     * @brief Adds a new queue to the scheduler (if supported).
+     *
+     * @param queue_id The unique identifier for the queue to add.
+     * @param weight_or_priority The scheduling weight (for WFQ/WRR) or priority level.
+     *                           The interpretation depends on the scheduler implementation.
+     */
+    // virtual void add_queue(core::QueueId queue_id, uint32_t weight_or_priority) = 0;
+
+    /**
+     * @brief Removes an existing queue from the scheduler (if supported).
+     *
+     * @param queue_id The unique identifier for the queue to remove.
+     */
+    // virtual void remove_queue(core::QueueId queue_id) = 0;
+
+    /**
+     * @brief Updates parameters for an existing queue (if supported).
+     *
+     * @param queue_id The unique identifier for the queue to update.
+     * @param new_weight_or_priority The new scheduling weight or priority level.
+     */
+    // virtual void update_queue(core::QueueId queue_id, uint32_t new_weight_or_priority) = 0;
+};
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_SCHEDULER_INTERFACE_H_

--- a/hqts/include/hqts/scheduler/strict_priority_scheduler.h
+++ b/hqts/include/hqts/scheduler/strict_priority_scheduler.h
@@ -1,0 +1,82 @@
+#ifndef HQTS_SCHEDULER_STRICT_PRIORITY_SCHEDULER_H_
+#define HQTS_SCHEDULER_STRICT_PRIORITY_SCHEDULER_H_
+
+#include "hqts/scheduler/scheduler_interface.h"
+#include "hqts/scheduler/queue_types.h" // For PacketQueue
+
+#include <vector>
+#include <stdexcept> // For std::out_of_range, std::invalid_argument, std::runtime_error
+#include <string>    // Potentially for error messages, though not strictly required by declarations
+
+namespace hqts {
+namespace scheduler {
+
+/**
+ * @brief Implements a Strict Priority Scheduler.
+ *
+ * This scheduler manages multiple priority queues. Packets are always dequeued
+ * from the highest-priority non-empty queue. Numerically higher priority values
+ * are treated as higher scheduling priority (e.g., priority 7 is served before priority 0).
+ */
+class StrictPriorityScheduler : public SchedulerInterface {
+public:
+    /**
+     * @brief Constructs a StrictPriorityScheduler.
+     * @param num_priority_levels The number of priority levels to manage (e.g., 8 for levels 0-7).
+     * @throws std::invalid_argument if num_priority_levels is 0.
+     */
+    explicit StrictPriorityScheduler(size_t num_priority_levels = 8);
+
+    ~StrictPriorityScheduler() override = default;
+
+    // Delete copy and move operations for simplicity, as managing underlying queues could be complex.
+    // If needed, these can be implemented with proper deep copy/move semantics.
+    StrictPriorityScheduler(const StrictPriorityScheduler&) = delete;
+    StrictPriorityScheduler& operator=(const StrictPriorityScheduler&) = delete;
+    StrictPriorityScheduler(StrictPriorityScheduler&&) = default; // Default move is fine if members are movable
+    StrictPriorityScheduler& operator=(StrictPriorityScheduler&&) = default; // Default move is fine
+
+    /**
+     * @brief Enqueues a packet based on its priority.
+     * @param packet The packet to enqueue. packet.priority determines the queue.
+     * @throws std::out_of_range if packet.priority is >= num_priority_levels.
+     */
+    void enqueue(PacketDescriptor packet) override;
+
+    /**
+     * @brief Dequeues a packet from the highest-priority non-empty queue.
+     * @return The dequeued PacketDescriptor.
+     * @throws std::runtime_error if the scheduler is empty.
+     */
+    PacketDescriptor dequeue() override;
+
+    /**
+     * @brief Checks if the scheduler is empty (no packets in any queue).
+     * @return True if all priority queues are empty, false otherwise.
+     */
+    bool is_empty() const override;
+
+    /**
+     * @brief Gets the configured number of priority levels.
+     * @return The number of priority levels.
+     */
+    size_t get_num_priority_levels() const;
+
+    /**
+     * @brief Gets the current number of packets in a specific priority queue.
+     * @param priority_level The priority level of the queue.
+     * @return The number of packets in that queue.
+     * @throws std::out_of_range if priority_level is >= num_priority_levels.
+     */
+    size_t get_queue_size(uint8_t priority_level) const;
+
+private:
+    std::vector<PacketQueue> priority_queues_;
+    const size_t num_levels_;
+    size_t total_packets_ = 0; // Total number of packets across all queues
+};
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_STRICT_PRIORITY_SCHEDULER_H_

--- a/hqts/include/hqts/scheduler/wrr_scheduler.h
+++ b/hqts/include/hqts/scheduler/wrr_scheduler.h
@@ -1,0 +1,116 @@
+#ifndef HQTS_SCHEDULER_WRR_SCHEDULER_H_
+#define HQTS_SCHEDULER_WRR_SCHEDULER_H_
+
+#include "hqts/scheduler/scheduler_interface.h"
+#include "hqts/scheduler/queue_types.h" // For PacketQueue
+#include "hqts/core/flow_context.h"     // For core::QueueId
+
+#include <vector>
+#include <map>
+#include <stdexcept> // For std::out_of_range, std::invalid_argument, std::runtime_error, std::logic_error
+#include <string>    // Potentially for error messages
+#include <numeric>   // For std::accumulate or other numeric operations if needed later
+
+namespace hqts {
+namespace scheduler {
+
+/**
+ * @brief Implements a packet-based Weighted Round Robin (WRR) Scheduler.
+ *
+ * This scheduler serves a configured set of queues. Each queue has a weight.
+ * In each round, queues are visited. A queue can dequeue a number of packets
+ * proportional to its weight (in this simple packet WRR, it means it gets
+ * 'weight' chances to send one packet if its deficit allows).
+ *
+ * Note: For this implementation, PacketDescriptor::priority is used as the
+ * core::QueueId to determine which queue to enqueue into. This is a simplification.
+ */
+class WrrScheduler : public SchedulerInterface {
+public:
+    struct QueueConfig {
+        core::QueueId id; // User-defined ID for the queue
+        uint32_t weight;  // Weight for this queue (must be > 0)
+
+        QueueConfig(core::QueueId q_id, uint32_t w) : id(q_id), weight(w) {}
+    };
+
+    /**
+     * @brief Constructs a WrrScheduler.
+     * @param queue_configs A vector of QueueConfig structs defining the queues and their weights.
+     * @throws std::invalid_argument if queue_configs is empty or any queue has weight 0.
+     */
+    explicit WrrScheduler(const std::vector<QueueConfig>& queue_configs);
+
+    ~WrrScheduler() override = default;
+
+    // Delete copy and move operations for simplicity.
+    WrrScheduler(const WrrScheduler&) = delete;
+    WrrScheduler& operator=(const WrrScheduler&) = delete;
+    WrrScheduler(WrrScheduler&&) = default;
+    WrrScheduler& operator=(WrrScheduler&&) = default;
+
+    /**
+     * @brief Enqueues a packet. PacketDescriptor::priority is used as core::QueueId.
+     * @param packet The packet to enqueue.
+     * @throws std::logic_error if scheduler is not configured.
+     * @throws std::out_of_range if packet.priority (as QueueId) is not a configured queue.
+     */
+    void enqueue(PacketDescriptor packet) override;
+
+    /**
+     * @brief Dequeues a packet according to WRR discipline.
+     * @return The dequeued PacketDescriptor.
+     * @throws std::runtime_error if the scheduler is empty.
+     * @throws std::logic_error if scheduler is not configured or in an inconsistent state.
+     */
+    PacketDescriptor dequeue() override;
+
+    /**
+     * @brief Checks if the scheduler is empty (no packets in any queue).
+     * @return True if all queues are empty, false otherwise.
+     * @throws std::logic_error if scheduler is not configured.
+     */
+    bool is_empty() const override;
+
+    // Optional: Additional inspection methods
+    /**
+     * @brief Gets the current number of packets in a specific queue.
+     * @param queue_id The external ID of the queue.
+     * @return The number of packets in that queue.
+     * @throws std::out_of_range if queue_id is not a configured queue.
+     */
+    size_t get_queue_size(core::QueueId queue_id) const;
+
+    /**
+     * @brief Gets the number of configured queues.
+     * @return The number of queues.
+     */
+    size_t get_num_queues() const;
+
+
+private:
+    struct InternalQueueState {
+        PacketQueue packet_queue;
+        uint32_t weight;
+        int32_t current_deficit; // Represents the current allowance for this queue
+        core::QueueId external_id; // User-facing ID
+
+        InternalQueueState(core::QueueId ext_id, uint32_t w)
+            : weight(w), current_deficit(0), external_id(ext_id) {} // Deficit often starts at 0 or weight
+    };
+
+    std::vector<InternalQueueState> queues_;
+    std::map<core::QueueId, size_t> queue_id_to_index_; // Maps external QueueId to index in queues_ vector
+
+    size_t current_queue_index_ = 0; // Index for the next queue to consider in the round-robin scheme
+    size_t total_packets_ = 0;       // Total packets across all queues
+    bool is_configured_ = false;     // Tracks if constructor successfully configured queues
+
+    // Helper to replenish deficits for all queues if a full round yields no serviceable queue.
+    void replenish_all_deficits();
+};
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_WRR_SCHEDULER_H_

--- a/hqts/src/CMakeLists.txt
+++ b/hqts/src/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(hqts_core STATIC
     core/token_bucket.cpp
     core/shaping_policy.cpp
     core/flow_context.cpp
+    scheduler/strict_priority_scheduler.cpp # Added
+    scheduler/wrr_scheduler.cpp             # Added
 
     # Policy components (if any .cpp files existed, e.g. policy_tree.cpp)
     # policy/policy_tree.cpp

--- a/hqts/src/scheduler/strict_priority_scheduler.cpp
+++ b/hqts/src/scheduler/strict_priority_scheduler.cpp
@@ -1,0 +1,61 @@
+#include "hqts/scheduler/strict_priority_scheduler.h"
+#include <string> // Required for std::to_string in error messages
+
+namespace hqts {
+namespace scheduler {
+
+StrictPriorityScheduler::StrictPriorityScheduler(size_t num_priority_levels)
+    : num_levels_(num_priority_levels), total_packets_(0) {
+    if (num_priority_levels == 0) {
+        throw std::invalid_argument("Number of priority levels must be greater than 0.");
+    }
+    priority_queues_.resize(num_levels_);
+}
+
+void StrictPriorityScheduler::enqueue(PacketDescriptor packet) {
+    if (packet.priority >= num_levels_) {
+        throw std::out_of_range("Packet priority " + std::to_string(packet.priority) +
+                                " is out of range. Max allowed is " + std::to_string(num_levels_ - 1) + ".");
+    }
+    priority_queues_[packet.priority].push(std::move(packet)); // Use std::move if PacketDescriptor is movable
+    total_packets_++;
+}
+
+PacketDescriptor StrictPriorityScheduler::dequeue() {
+    if (is_empty()) {
+        throw std::runtime_error("Scheduler is empty, cannot dequeue.");
+    }
+
+    // Iterate from the highest priority queue down to the lowest
+    // Numerically higher priority value means higher scheduling priority
+    for (int i = static_cast<int>(num_levels_ - 1); i >= 0; --i) {
+        if (!priority_queues_[static_cast<size_t>(i)].empty()) {
+            PacketDescriptor packet = priority_queues_[static_cast<size_t>(i)].front();
+            priority_queues_[static_cast<size_t>(i)].pop();
+            total_packets_--;
+            return packet;
+        }
+    }
+    // This part should ideally not be reached if total_packets_ is managed correctly
+    // and is_empty() is checked. If it is reached, it implies an inconsistency.
+    throw std::logic_error("Scheduler state inconsistent: is_empty() was false, but no packet found.");
+}
+
+bool StrictPriorityScheduler::is_empty() const {
+    return total_packets_ == 0;
+}
+
+size_t StrictPriorityScheduler::get_num_priority_levels() const {
+    return num_levels_;
+}
+
+size_t StrictPriorityScheduler::get_queue_size(uint8_t priority_level) const {
+    if (priority_level >= num_levels_) {
+        throw std::out_of_range("Priority level " + std::to_string(priority_level) +
+                                " is out of range. Max allowed is " + std::to_string(num_levels_ - 1) + ".");
+    }
+    return priority_queues_[priority_level].size();
+}
+
+} // namespace scheduler
+} // namespace hqts

--- a/hqts/src/scheduler/wrr_scheduler.cpp
+++ b/hqts/src/scheduler/wrr_scheduler.cpp
@@ -1,0 +1,146 @@
+#include "hqts/scheduler/wrr_scheduler.h"
+#include <string> // For std::to_string in error messages
+#include <numeric> // For std::gcd if a more complex deficit scheme was used, not directly needed now.
+
+namespace hqts {
+namespace scheduler {
+
+WrrScheduler::WrrScheduler(const std::vector<QueueConfig>& queue_configs)
+    : current_queue_index_(0), total_packets_(0), is_configured_(false) {
+    if (queue_configs.empty()) {
+        throw std::invalid_argument("WRR Scheduler: queue_configs cannot be empty.");
+    }
+
+    queues_.reserve(queue_configs.size());
+    for (size_t i = 0; i < queue_configs.size(); ++i) {
+        const auto& qc = queue_configs[i];
+        if (qc.weight == 0) {
+            throw std::invalid_argument("WRR Scheduler: Queue weight for ID " + std::to_string(qc.id) + " cannot be zero.");
+        }
+        if (queue_id_to_index_.count(qc.id)) {
+            throw std::invalid_argument("WRR Scheduler: Duplicate QueueId " + std::to_string(qc.id) + " in configuration.");
+        }
+
+        queues_.emplace_back(qc.id, qc.weight);
+        // Initialize current_deficit. Common practice is to start with weight, or 0.
+        // Let's start with 0, and they get replenished before first service attempt if all are 0.
+        // Or, to start them with their weight to allow immediate service:
+        queues_.back().current_deficit = static_cast<int32_t>(qc.weight);
+        queue_id_to_index_[qc.id] = i;
+    }
+    is_configured_ = true;
+}
+
+void WrrScheduler::enqueue(PacketDescriptor packet) {
+    if (!is_configured_) {
+        throw std::logic_error("WRR Scheduler: Not configured. Call constructor with queue configurations.");
+    }
+
+    // Using packet.priority as the core::QueueId for this scheduler
+    core::QueueId target_queue_external_id = static_cast<core::QueueId>(packet.priority);
+
+    auto it = queue_id_to_index_.find(target_queue_external_id);
+    if (it == queue_id_to_index_.end()) {
+        throw std::out_of_range("WRR Scheduler: QueueId " + std::to_string(target_queue_external_id) +
+                                " (from packet.priority) not configured for this scheduler.");
+    }
+
+    queues_[it->second].packet_queue.push(std::move(packet));
+    total_packets_++;
+}
+
+void WrrScheduler::replenish_all_deficits() {
+    for (InternalQueueState& q_state : queues_) {
+        q_state.current_deficit += static_cast<int32_t>(q_state.weight);
+    }
+}
+
+PacketDescriptor WrrScheduler::dequeue() {
+    if (!is_configured_) {
+        throw std::logic_error("WRR Scheduler: Not configured.");
+    }
+    if (is_empty()) {
+        throw std::runtime_error("WRR Scheduler: Scheduler is empty, cannot dequeue.");
+    }
+
+    size_t num_queues = queues_.size();
+    size_t queues_checked_this_round = 0;
+    bool deficits_replenished_this_attempt = false;
+
+    while (true) { // Loop indefinitely until a packet is dequeued or an error state is identified
+        queues_checked_this_round = 0;
+        bool can_service_any_queue_in_current_state = false;
+
+        for (size_t i = 0; i < num_queues; ++i) {
+            // Start check from current_queue_index_ and wrap around
+            size_t actual_index = (current_queue_index_ + i) % num_queues;
+            InternalQueueState& current_q_state = queues_[actual_index];
+
+            if (!current_q_state.packet_queue.empty() && current_q_state.current_deficit > 0) {
+                can_service_any_queue_in_current_state = true; // Found a queue that could be serviced
+
+                PacketDescriptor packet = current_q_state.packet_queue.front();
+                current_q_state.packet_queue.pop();
+                current_q_state.current_deficit--;
+                total_packets_--;
+
+                // Advance current_queue_index_ to the next queue for the next dequeue operation.
+                // WRR typically advances after a packet is sent, or after a queue empties its deficit.
+                // For simple packet WRR, advance after each packet.
+                current_queue_index_ = (actual_index + 1) % num_queues;
+                return packet;
+            }
+        }
+
+        // If we've gone through all queues and couldn't service any (e.g. all non-empty queues have 0 deficit)
+        if (!can_service_any_queue_in_current_state) {
+            if (deficits_replenished_this_attempt) {
+                // This should not happen if there are packets. It means deficits were replenished,
+                // but still no queue could be serviced (e.g. all queues became empty simultaneously,
+                // but total_packets_ > 0, which is an inconsistency).
+                 throw std::logic_error("WRR Scheduler: Inconsistent state. Deficits replenished but no packet dequeued while not empty.");
+            }
+            replenish_all_deficits();
+            deficits_replenished_this_attempt = true; // Mark that we've tried replenishing in this dequeue call
+            // Restart the scan from current_queue_index_ (or 0 if preferred for strict round start)
+            // current_queue_index_ remains, so the next iteration of the while(true) loop will retry.
+        } else {
+            // This case should ideally not be hit if the inner loop correctly services a queue.
+            // If can_service_any_queue_in_current_state is true, a packet should have been returned.
+            // If it's false, the block above should have been hit.
+            // This is a safeguard.
+        }
+         // The while(true) loop continues, either after replenishing or if some logic error prevented dequeue.
+    }
+}
+
+
+bool WrrScheduler::is_empty() const {
+    if (!is_configured_) {
+        // Or return true, or handle as per desired semantics for unconfigured state
+        throw std::logic_error("WRR Scheduler: Not configured.");
+    }
+    return total_packets_ == 0;
+}
+
+size_t WrrScheduler::get_queue_size(core::QueueId queue_id) const {
+    if (!is_configured_) {
+        throw std::logic_error("WRR Scheduler: Not configured.");
+    }
+    auto it = queue_id_to_index_.find(queue_id);
+    if (it == queue_id_to_index_.end()) {
+        throw std::out_of_range("WRR Scheduler: QueueId " + std::to_string(queue_id) + " not configured.");
+    }
+    return queues_[it->second].packet_queue.size();
+}
+
+size_t WrrScheduler::get_num_queues() const {
+    if (!is_configured_) {
+        // Or return 0, or handle as per desired semantics for unconfigured state
+        throw std::logic_error("WRR Scheduler: Not configured.");
+    }
+    return queues_.size();
+}
+
+} // namespace scheduler
+} // namespace hqts

--- a/hqts/tests/CMakeLists.txt
+++ b/hqts/tests/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(run_hqts_tests
     unit/core/test_token_bucket.cpp
     unit/policy/test_policy_tree.cpp
     unit/dataplane/test_flow_table.cpp
+    unit/scheduler/test_strict_priority_scheduler.cpp # Added
+    unit/scheduler/test_wrr_scheduler.cpp             # Added
     # Add new test_*.cpp files here as they are created
 )
 

--- a/hqts/tests/unit/scheduler/test_strict_priority_scheduler.cpp
+++ b/hqts/tests/unit/scheduler/test_strict_priority_scheduler.cpp
@@ -1,0 +1,186 @@
+#include "gtest/gtest.h"
+#include "hqts/scheduler/strict_priority_scheduler.h"
+#include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
+#include "hqts/core/flow_context.h"          // For core::FlowId (used in PacketDescriptor)
+
+#include <vector>
+#include <stdexcept> // For std::invalid_argument, std::out_of_range, std::runtime_error
+
+namespace hqts {
+namespace scheduler {
+
+// Helper to create a PacketDescriptor for tests
+PacketDescriptor createTestPacket(core::FlowId flow_id, uint32_t length, uint8_t priority, size_t payload_size = 0) {
+    // Assuming PacketDescriptor constructor: PacketDescriptor(core::FlowId f_id, uint32_t len, uint8_t prio, size_t payload_size = 0)
+    return PacketDescriptor(flow_id, length, priority, payload_size);
+}
+
+TEST(StrictPrioritySchedulerTest, Constructor) {
+    ASSERT_NO_THROW(StrictPriorityScheduler scheduler(8));
+    ASSERT_THROW(StrictPriorityScheduler scheduler_invalid(0), std::invalid_argument);
+
+    StrictPriorityScheduler scheduler(4);
+    ASSERT_EQ(scheduler.get_num_priority_levels(), 4);
+    ASSERT_TRUE(scheduler.is_empty());
+    // Check initial queue sizes
+    for (uint8_t i = 0; i < 4; ++i) {
+        ASSERT_EQ(scheduler.get_queue_size(i), 0);
+    }
+}
+
+TEST(StrictPrioritySchedulerTest, EnqueueAndDequeueSinglePacket) {
+    StrictPriorityScheduler scheduler(8);
+    PacketDescriptor p1 = createTestPacket(1, 100, 3);
+
+    scheduler.enqueue(p1);
+    ASSERT_FALSE(scheduler.is_empty());
+    ASSERT_EQ(scheduler.get_queue_size(3), 1);
+    // Check other queues are empty
+    for (uint8_t i = 0; i < 8; ++i) {
+        if (i != 3) {
+            ASSERT_EQ(scheduler.get_queue_size(i), 0);
+        }
+    }
+
+    PacketDescriptor dequeued_p = scheduler.dequeue();
+    ASSERT_EQ(dequeued_p.flow_id, p1.flow_id);
+    ASSERT_EQ(dequeued_p.priority, p1.priority);
+    ASSERT_EQ(dequeued_p.packet_length_bytes, p1.packet_length_bytes);
+    ASSERT_TRUE(scheduler.is_empty());
+    ASSERT_EQ(scheduler.get_queue_size(3), 0);
+}
+
+TEST(StrictPrioritySchedulerTest, DequeueFromEmpty) {
+    StrictPriorityScheduler scheduler(8);
+    ASSERT_TRUE(scheduler.is_empty());
+    ASSERT_THROW(scheduler.dequeue(), std::runtime_error);
+}
+
+TEST(StrictPrioritySchedulerTest, EnqueueInvalidPriority) {
+    StrictPriorityScheduler scheduler(4); // Priorities 0, 1, 2, 3
+    PacketDescriptor p_valid_high = createTestPacket(1, 100, 3);
+    PacketDescriptor p_invalid_too_high = createTestPacket(2, 100, 4);
+    PacketDescriptor p_invalid_way_too_high = createTestPacket(3, 100, 255);
+
+    ASSERT_NO_THROW(scheduler.enqueue(p_valid_high));
+    ASSERT_THROW(scheduler.enqueue(p_invalid_too_high), std::out_of_range);
+    ASSERT_THROW(scheduler.enqueue(p_invalid_way_too_high), std::out_of_range);
+}
+
+TEST(StrictPrioritySchedulerTest, GetQueueSizeInvalidPriority) {
+    StrictPriorityScheduler scheduler(4);
+    ASSERT_THROW(scheduler.get_queue_size(4), std::out_of_range);
+    ASSERT_THROW(scheduler.get_queue_size(255), std::out_of_range);
+    ASSERT_NO_THROW(scheduler.get_queue_size(0));
+    ASSERT_NO_THROW(scheduler.get_queue_size(3));
+}
+
+TEST(StrictPrioritySchedulerTest, StrictPriorityOrder) {
+    StrictPriorityScheduler scheduler(4); // Prio levels 0, 1, 2, 3 (3 is highest sched prio)
+    PacketDescriptor p_low = createTestPacket(10, 100, 0);    // Lowest prio
+    PacketDescriptor p_mid = createTestPacket(20, 100, 1);    // Mid prio
+    PacketDescriptor p_high = createTestPacket(30, 100, 3);   // Highest prio
+    PacketDescriptor p_mid2 = createTestPacket(40, 100, 1);   // Another mid prio
+
+    scheduler.enqueue(p_low);   // Prio 0
+    scheduler.enqueue(p_mid);   // Prio 1
+    scheduler.enqueue(p_high);  // Prio 3
+    scheduler.enqueue(p_mid2);  // Prio 1, enqueued after p_high, but lower prio than p_high
+
+    ASSERT_EQ(scheduler.get_queue_size(0), 1);
+    ASSERT_EQ(scheduler.get_queue_size(1), 2);
+    ASSERT_EQ(scheduler.get_queue_size(2), 0); // Ensure other queues are empty
+    ASSERT_EQ(scheduler.get_queue_size(3), 1);
+    ASSERT_FALSE(scheduler.is_empty());
+
+    // Dequeue order should be: p_high (3), p_mid (1), p_mid2 (1), p_low (0)
+    PacketDescriptor dequeued;
+
+    dequeued = scheduler.dequeue();
+    ASSERT_EQ(dequeued.flow_id, p_high.flow_id);
+    ASSERT_EQ(dequeued.priority, 3);
+    ASSERT_EQ(scheduler.get_queue_size(3), 0);
+
+    dequeued = scheduler.dequeue();
+    ASSERT_EQ(dequeued.flow_id, p_mid.flow_id);
+    ASSERT_EQ(dequeued.priority, 1);
+    ASSERT_EQ(scheduler.get_queue_size(1), 1);
+
+    dequeued = scheduler.dequeue();
+    ASSERT_EQ(dequeued.flow_id, p_mid2.flow_id);
+    ASSERT_EQ(dequeued.priority, 1);
+    ASSERT_EQ(scheduler.get_queue_size(1), 0);
+
+    dequeued = scheduler.dequeue();
+    ASSERT_EQ(dequeued.flow_id, p_low.flow_id);
+    ASSERT_EQ(dequeued.priority, 0);
+    ASSERT_EQ(scheduler.get_queue_size(0), 0);
+
+    ASSERT_TRUE(scheduler.is_empty());
+}
+
+TEST(StrictPrioritySchedulerTest, MultiplePacketsSamePriority) {
+    StrictPriorityScheduler scheduler(3); // Prio 0, 1, 2
+    PacketDescriptor p1_prio1 = createTestPacket(1, 100, 1);
+    PacketDescriptor p2_prio1 = createTestPacket(2, 100, 1);
+    PacketDescriptor p3_prio0 = createTestPacket(3, 100, 0);
+
+    scheduler.enqueue(p1_prio1);
+    scheduler.enqueue(p3_prio0); // Lower priority, enqueued before p2_prio1
+    scheduler.enqueue(p2_prio1); // Same priority as p1, enqueued later
+
+    // Expected order: p1_prio1 (1), p2_prio1 (1) (FIFO within priority), then p3_prio0 (0)
+    PacketDescriptor dequeued;
+
+    dequeued = scheduler.dequeue(); // Highest available is Prio 1
+    ASSERT_EQ(dequeued.flow_id, p1_prio1.flow_id);
+    ASSERT_EQ(dequeued.priority, 1);
+
+    dequeued = scheduler.dequeue(); // Next is also Prio 1
+    ASSERT_EQ(dequeued.flow_id, p2_prio1.flow_id);
+    ASSERT_EQ(dequeued.priority, 1);
+
+    dequeued = scheduler.dequeue(); // Last is Prio 0
+    ASSERT_EQ(dequeued.flow_id, p3_prio0.flow_id);
+    ASSERT_EQ(dequeued.priority, 0);
+
+    ASSERT_TRUE(scheduler.is_empty());
+}
+
+TEST(StrictPrioritySchedulerTest, FillAndEmptyMultipleLevels) {
+    StrictPriorityScheduler scheduler(2); // Prio 0 (low), 1 (high)
+    const int num_packets_per_level = 5;
+
+    // Enqueue packets: Prio 1 first, then Prio 0
+    for (int i = 0; i < num_packets_per_level; ++i) {
+        scheduler.enqueue(createTestPacket(100u + static_cast<core::FlowId>(i), 10, 1)); // High prio
+    }
+    for (int i = 0; i < num_packets_per_level; ++i) {
+        scheduler.enqueue(createTestPacket(200u + static_cast<core::FlowId>(i), 10, 0)); // Low prio
+    }
+
+    ASSERT_EQ(scheduler.get_queue_size(1), num_packets_per_level);
+    ASSERT_EQ(scheduler.get_queue_size(0), num_packets_per_level);
+    ASSERT_FALSE(scheduler.is_empty());
+
+    // Dequeue all high priority packets
+    for (int i = 0; i < num_packets_per_level; ++i) {
+        PacketDescriptor p = scheduler.dequeue();
+        ASSERT_EQ(p.priority, 1);
+        ASSERT_EQ(p.flow_id, 100u + static_cast<core::FlowId>(i));
+    }
+    ASSERT_EQ(scheduler.get_queue_size(1), 0);
+    ASSERT_FALSE(scheduler.is_empty()); // Low priority packets should still be there
+
+    // Dequeue all low priority packets
+    for (int i = 0; i < num_packets_per_level; ++i) {
+        PacketDescriptor p = scheduler.dequeue();
+        ASSERT_EQ(p.priority, 0);
+        ASSERT_EQ(p.flow_id, 200u + static_cast<core::FlowId>(i));
+    }
+    ASSERT_EQ(scheduler.get_queue_size(0), 0);
+    ASSERT_TRUE(scheduler.is_empty());
+}
+
+} // namespace scheduler
+} // namespace hqts

--- a/hqts/tests/unit/scheduler/test_wrr_scheduler.cpp
+++ b/hqts/tests/unit/scheduler/test_wrr_scheduler.cpp
@@ -1,0 +1,254 @@
+#include "gtest/gtest.h"
+#include "hqts/scheduler/wrr_scheduler.h"
+#include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
+#include "hqts/core/flow_context.h"      // For core::QueueId, core::FlowId
+
+#include <vector>
+#include <map>
+#include <numeric>   // For std::accumulate if needed, or std::gcd for advanced tests
+#include <stdexcept> // For std::invalid_argument etc.
+
+namespace hqts {
+namespace scheduler {
+
+// Helper to create a PacketDescriptor. Priority field is used as QueueId for WRR.
+PacketDescriptor createWrrTestPacket(core::FlowId flow_id, uint32_t length, core::QueueId queue_id_for_wrr) {
+    // Using priority field of PacketDescriptor to denote the target QueueId for WRR
+    // Ensure that the queue_id_for_wrr can be safely cast to uint8_t for packet.priority
+    if (queue_id_for_wrr > UINT8_MAX) {
+        throw std::overflow_error("Queue ID for WRR test packet exceeds uint8_t max value.");
+    }
+    return PacketDescriptor(flow_id, length, static_cast<uint8_t>(queue_id_for_wrr));
+}
+
+TEST(WrrSchedulerTest, ConstructorValidation) {
+    // Empty config
+    std::vector<WrrScheduler::QueueConfig> empty_configs;
+    ASSERT_THROW(WrrScheduler scheduler(empty_configs), std::invalid_argument);
+
+    // Config with zero weight
+    std::vector<WrrScheduler::QueueConfig> zero_weight_configs = {{static_cast<core::QueueId>(1), 0}};
+    ASSERT_THROW(WrrScheduler scheduler(zero_weight_configs), std::invalid_argument);
+
+    std::vector<WrrScheduler::QueueConfig> zero_weight_configs2 = {
+        {static_cast<core::QueueId>(1), 10},
+        {static_cast<core::QueueId>(2), 0}
+    };
+    ASSERT_THROW(WrrScheduler scheduler(zero_weight_configs2), std::invalid_argument);
+
+    // Duplicate Queue IDs
+    std::vector<WrrScheduler::QueueConfig> duplicate_id_configs = {
+        {static_cast<core::QueueId>(1), 10},
+        {static_cast<core::QueueId>(1), 20}
+    };
+    ASSERT_THROW(WrrScheduler scheduler(duplicate_id_configs), std::invalid_argument);
+
+    // Valid config
+    std::vector<WrrScheduler::QueueConfig> valid_configs = {
+        {static_cast<core::QueueId>(1), 10},
+        {static_cast<core::QueueId>(2), 20}
+    };
+    ASSERT_NO_THROW(WrrScheduler scheduler(valid_configs));
+    WrrScheduler scheduler(valid_configs);
+    ASSERT_EQ(scheduler.get_num_queues(), 2);
+    ASSERT_TRUE(scheduler.is_empty());
+}
+
+TEST(WrrSchedulerTest, EnqueueAndDequeueSinglePacket) {
+    std::vector<WrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(100), 1}};
+    WrrScheduler scheduler(configs);
+
+    PacketDescriptor p1 = createWrrTestPacket(1, 100, 100); // queue_id 100
+    scheduler.enqueue(p1);
+    ASSERT_FALSE(scheduler.is_empty());
+    ASSERT_EQ(scheduler.get_queue_size(100), 1);
+
+    PacketDescriptor dequeued_p = scheduler.dequeue();
+    ASSERT_EQ(dequeued_p.flow_id, p1.flow_id);
+    // Recall: p1.priority holds the queue_id for this test helper
+    ASSERT_EQ(dequeued_p.priority, static_cast<uint8_t>(100));
+    ASSERT_TRUE(scheduler.is_empty());
+    ASSERT_EQ(scheduler.get_queue_size(100), 0);
+}
+
+TEST(WrrSchedulerTest, DequeueFromEmpty) {
+    std::vector<WrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(1), 1}};
+    WrrScheduler scheduler(configs);
+    ASSERT_TRUE(scheduler.is_empty());
+    ASSERT_THROW(scheduler.dequeue(), std::runtime_error);
+}
+
+TEST(WrrSchedulerTest, EnqueueInvalidQueueId) {
+    std::vector<WrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(1), 10}}; // Only queue_id 1 is configured
+    WrrScheduler scheduler(configs);
+    PacketDescriptor p_valid = createWrrTestPacket(1, 100, 1);
+    PacketDescriptor p_invalid_q_id = createWrrTestPacket(2, 100, 2); // queue_id 2 not configured
+
+    ASSERT_NO_THROW(scheduler.enqueue(p_valid));
+    ASSERT_THROW(scheduler.enqueue(p_invalid_q_id), std::out_of_range);
+}
+
+TEST(WrrSchedulerTest, GetQueueSizeInvalidQueueId) {
+    std::vector<WrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(1), 10}};
+    WrrScheduler scheduler(configs);
+    ASSERT_THROW(scheduler.get_queue_size(2), std::out_of_range); // qid 2 not configured
+    ASSERT_NO_THROW(scheduler.get_queue_size(1));
+    ASSERT_EQ(scheduler.get_queue_size(1),0);
+}
+
+TEST(WrrSchedulerTest, BasicWeightDistribution) {
+    std::vector<WrrScheduler::QueueConfig> configs = {
+        {static_cast<core::QueueId>(1), 1},
+        {static_cast<core::QueueId>(2), 2}
+    }; // Q1 (w=1), Q2 (w=2)
+    WrrScheduler scheduler(configs);
+
+    // Enqueue 3 packets for Q1, 6 for Q2 (maintaining proportions for multiple rounds)
+    for (int i = 0; i < 3; ++i) scheduler.enqueue(createWrrTestPacket(10 + i, 100, 1));
+    for (int i = 0; i < 6; ++i) scheduler.enqueue(createWrrTestPacket(20 + i, 100, 2));
+
+    ASSERT_EQ(scheduler.get_queue_size(1), 3);
+    ASSERT_EQ(scheduler.get_queue_size(2), 6);
+
+    std::map<core::QueueId, int> dequeued_counts;
+    for (int i = 0; i < 9; ++i) { // Total 9 packets
+        PacketDescriptor p = scheduler.dequeue();
+        // p.priority field was used to store QueueId
+        dequeued_counts[static_cast<core::QueueId>(p.priority)]++;
+    }
+
+    ASSERT_TRUE(scheduler.is_empty());
+    // Expected: Q1 gets 1/3, Q2 gets 2/3. So 3 packets from Q1, 6 from Q2.
+    ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(1)], 3);
+    ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(2)], 6);
+}
+
+TEST(WrrSchedulerTest, WeightDistributionSpecificOrderOneRound) {
+    std::vector<WrrScheduler::QueueConfig> configs = {
+        {static_cast<core::QueueId>(1), 1},
+        {static_cast<core::QueueId>(2), 2}
+    };
+    WrrScheduler scheduler(configs); // Deficits start at weight: Q1(d=1), Q2(d=2)
+
+    scheduler.enqueue(createWrrTestPacket(10, 100, 1)); // Q1
+    scheduler.enqueue(createWrrTestPacket(11, 100, 1)); // Q1
+    scheduler.enqueue(createWrrTestPacket(20, 100, 2)); // Q2
+    scheduler.enqueue(createWrrTestPacket(21, 100, 2)); // Q2
+    scheduler.enqueue(createWrrTestPacket(22, 100, 2)); // Q2
+
+    // Expect order based on initial deficit = weight, and round-robin:
+    // Assumes current_queue_index_ starts at 0 (queue ID 1)
+    // 1. Q1 (id=1, w=1, d=1). Dequeue fid=10. Q1 d=0. counts[1]=1. scheduler.current_queue_index_ becomes 1 (for Q2).
+    // 2. Q2 (id=2, w=2, d=2). Dequeue fid=20. Q2 d=1. counts[2]=1. scheduler.current_queue_index_ becomes 0 (for Q1).
+    // 3. Q1 (id=1, w=1, d=0). Cannot dequeue. scheduler.current_queue_index_ becomes 1 (for Q2). (This step is skipped if only positive deficit queues are chosen)
+    //    Actually, the WRR loop will search for the next available queue with deficit.
+    //    If scheduler.current_queue_index_ is 1 (for Q2):
+    //    Dequeue fid=20 from Q2. Q2 deficit becomes 1. index advances to 0 (Q1).
+    //    Dequeue fid=10 from Q1. Q1 deficit becomes 0. index advances to 1 (Q2).
+    //    Dequeue fid=21 from Q2. Q2 deficit becomes 0. index advances to 0 (Q1).
+    //    Now all deficits are 0. Replenish. Q1 d=1, Q2 d=2.
+    //    Dequeue fid=11 from Q1. Q1 d=0. index advances to 1 (Q2).
+    //    Dequeue fid=22 from Q2. Q2 d=1. index advances to 0 (Q1).
+
+
+    std::vector<core::QueueId> expected_order = {1, 2, 2, 1, 2}; // Approximate for 2 packets Q1, 3 from Q2
+                                                               // Exact order: Q1(1), Q2(1), Q2(1), then replenish, then Q1(1), Q2(1)
+                                                               // Total 2 from Q1, 3 from Q2.
+
+    // A more deterministic way to test order is to enqueue just enough for one "WRR round" based on weights.
+    // Q1 (w=1), Q2 (w=2). Round is 3 packets.
+    // Enqueue 1 for Q1, 2 for Q2.
+    WrrScheduler scheduler2(configs);
+    scheduler2.enqueue(createWrrTestPacket(10,100,1));
+    scheduler2.enqueue(createWrrTestPacket(20,100,2));
+    scheduler2.enqueue(createWrrTestPacket(21,100,2));
+
+    std::map<core::QueueId, int> round_counts;
+    round_counts[scheduler2.dequeue().priority]++;
+    round_counts[scheduler2.dequeue().priority]++;
+    round_counts[scheduler2.dequeue().priority]++;
+
+    ASSERT_EQ(round_counts[1], 1);
+    ASSERT_EQ(round_counts[2], 2);
+
+}
+
+
+TEST(WrrSchedulerTest, WeightDistributionWithEmptyQueues) {
+    std::vector<WrrScheduler::QueueConfig> configs = {
+        {static_cast<core::QueueId>(1), 1},
+        {static_cast<core::QueueId>(2), 3}
+    }; // Q1 (w=1), Q2 (w=3)
+    WrrScheduler scheduler(configs);
+
+    // Enqueue 5 packets for Q2 only
+    for (int i = 0; i < 5; ++i) scheduler.enqueue(createWrrTestPacket(20 + i, 100, 2));
+
+    ASSERT_EQ(scheduler.get_queue_size(1), 0);
+    ASSERT_EQ(scheduler.get_queue_size(2), 5);
+
+    // All 5 dequeued packets should be from Q2
+    for (int i = 0; i < 5; ++i) {
+        PacketDescriptor p = scheduler.dequeue();
+        ASSERT_EQ(static_cast<core::QueueId>(p.priority), static_cast<core::QueueId>(2));
+    }
+    ASSERT_TRUE(scheduler.is_empty());
+
+    // Enqueue to Q1, then Q2. Then Q1 becomes empty.
+    scheduler.enqueue(createWrrTestPacket(10, 100, 1)); // 1 packet to Q1
+    for (int i = 0; i < 6; ++i) scheduler.enqueue(createWrrTestPacket(30 + i, 100, 2)); // 6 packets to Q2
+
+    // First packet should be from Q1 (weight 1, deficit starts at 1)
+    PacketDescriptor p_q1 = scheduler.dequeue();
+    ASSERT_EQ(static_cast<core::QueueId>(p_q1.priority), static_cast<core::QueueId>(1));
+
+    // Next 3 packets from Q2 (weight 3, deficit starts at 3)
+    for(int i=0; i<3; ++i) {
+         PacketDescriptor p = scheduler.dequeue();
+         ASSERT_EQ(static_cast<core::QueueId>(p.priority), static_cast<core::QueueId>(2));
+    }
+    // Deficits: Q1=0, Q2=0. Replenish. Q1=1, Q2=3.
+    // Q1 is empty.
+    // Next 3 packets from Q2.
+    for(int i=0; i<3; ++i) {
+         PacketDescriptor p = scheduler.dequeue();
+         ASSERT_EQ(static_cast<core::QueueId>(p.priority), static_cast<core::QueueId>(2));
+    }
+    ASSERT_TRUE(scheduler.is_empty());
+}
+
+TEST(WrrSchedulerTest, ComplexDistributionMultipleRounds) {
+    std::vector<WrrScheduler::QueueConfig> configs = {
+        {static_cast<core::QueueId>(1), 1},
+        {static_cast<core::QueueId>(2), 2},
+        {static_cast<core::QueueId>(3), 3}
+    }; // Q1 (w=1), Q2 (w=2), Q3 (w=3). Total weight sum = 6
+    WrrScheduler scheduler(configs);
+
+    // Enqueue packets for 2 "grand rounds" (LCM of weights or just many)
+    // 2 packets for Q1 (2 * w1)
+    // 4 packets for Q2 (2 * w2)
+    // 6 packets for Q3 (2 * w3)
+    // Total = 12 packets
+    for (int i = 0; i < 2; ++i) scheduler.enqueue(createWrrTestPacket(100 + i, 100, 1));
+    for (int i = 0; i < 4; ++i) scheduler.enqueue(createWrrTestPacket(200 + i, 100, 2));
+    for (int i = 0; i < 6; ++i) scheduler.enqueue(createWrrTestPacket(300 + i, 100, 3));
+
+    std::map<core::QueueId, int> dequeued_counts;
+    for (int i = 0; i < 12; ++i) {
+        PacketDescriptor p = scheduler.dequeue();
+        dequeued_counts[static_cast<core::QueueId>(p.priority)]++;
+    }
+
+    ASSERT_TRUE(scheduler.is_empty());
+    // Proportions should be 1:2:3, so for 12 packets:
+    // Q1: (1/6) * 12 = 2
+    // Q2: (2/6) * 12 = 4
+    // Q3: (3/6) * 12 = 6
+    ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(1)], 2);
+    ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(2)], 4);
+    ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(3)], 6);
+}
+
+} // namespace scheduler
+} // namespace hqts


### PR DESCRIPTION
This commit introduces the foundational components for packet scheduling as part of Phase 2, including scheduler interfaces and two concrete scheduler implementations: Strict Priority and Weighted Round Robin (WRR).

Key additions:
1.  Scheduler Infrastructure:
    - Defined `PacketDescriptor` (`scheduler/packet_descriptor.h`) to represent packets within the scheduling system.
    - Established `SchedulerInterface` (`scheduler/scheduler_interface.h`), an abstract base class defining common scheduler operations (`enqueue`, `dequeue`, `is_empty`).
    - Created `PacketQueue` type alias (`scheduler/queue_types.h`) for packet queues.

2.  Strict Priority Scheduler:
    - Implemented `StrictPriorityScheduler` (`scheduler/strict_priority_scheduler.h/cpp`).
    - This scheduler manages a configurable number of priority levels and always services the highest-priority non-empty queue in a FIFO manner within that priority.
    - Added comprehensive Gtests (`tests/unit/scheduler/test_strict_priority_scheduler.cpp`) validating its priority logic, FIFO behavior, and error handling.

3.  Weighted Round Robin (WRR) Scheduler:
    - Implemented `WrrScheduler` (`scheduler/wrr_scheduler.h/cpp`).
    - This is a packet-based WRR scheduler that uses a deficit-based mechanism to distribute packet transmission opportunities among queues according to their configured weights.
    - Added comprehensive Gtests (`tests/unit/scheduler/test_wrr_scheduler.cpp`) verifying constructor logic, enqueue/dequeue operations, correct weight-based distribution over multiple rounds, and behavior with empty queues.

4.  CMake Updates:
    - Updated `src/CMakeLists.txt` and `tests/CMakeLists.txt` to include all new source files for the schedulers and their unit tests, ensuring they are compiled and tested as part of the build.

This work lays the groundwork for more advanced scheduling algorithms and queue management features planned for later in Phase 2. All new components are unit-tested.