### PR TITLE
feat: Implement RedAqmQueue for Active Queue Management

### DIFF
--- a/hqts/include/hqts/scheduler/aqm_queue.h
+++ b/hqts/include/hqts/scheduler/aqm_queue.h
@@ -1,0 +1,96 @@
+#ifndef HQTS_SCHEDULER_AQM_QUEUE_H_
+#define HQTS_SCHEDULER_AQM_QUEUE_H_
+
+#include "hqts/scheduler/packet_descriptor.h"
+#include "hqts/scheduler/queue_types.h" // For PacketQueue (std::queue<PacketDescriptor>)
+#include <cstdint>
+#include <deque> // std::deque is often more suitable for average queue size tracking than std::queue
+#include <string> // For potential error messages
+#include <stdexcept> // For exceptions
+#include <chrono> // For time if needed for EWMA weight calculation or stats
+
+namespace hqts {
+namespace scheduler {
+
+// Parameters for RED AQM
+struct RedAqmParameters {
+    uint32_t min_threshold_bytes;  // Minimum average queue size before any drops
+    uint32_t max_threshold_bytes;  // Average queue size at which drop probability reaches max_p
+    double max_probability;        // Maximum drop probability (e.g., 0.1 for 10%)
+    double ewma_weight;            // Weight for EWMA average queue size calculation (e.g., 0.002)
+    uint32_t queue_capacity_bytes; // Physical capacity of the queue
+
+    // Constructor for sensible defaults or specific settings
+    RedAqmParameters(uint32_t min_t, uint32_t max_t, double max_p, double weight, uint32_t capacity)
+        : min_threshold_bytes(min_t), max_threshold_bytes(max_t),
+          max_probability(max_p), ewma_weight(weight), queue_capacity_bytes(capacity) {
+        if (min_t == 0 || max_t == 0 || capacity == 0 || min_t >= max_t || max_t > capacity || weight <= 0.0 || weight >= 1.0 || max_p <= 0.0 || max_p > 1.0) {
+            // Consider more specific error messages for each condition if desired
+            throw std::invalid_argument("Invalid RED AQM parameters provided to constructor.");
+        }
+    }
+};
+
+// Interface for an AQM-enabled queue (optional, can directly implement RedAqmQueue)
+// For now, let's proceed directly with RedAqmQueue. If other AQMs are added, an interface can be refactored.
+
+class RedAqmQueue {
+public:
+    explicit RedAqmQueue(const RedAqmParameters& params);
+
+    // Attempts to enqueue a packet. Returns true on success, false if dropped by RED or if queue is at physical capacity.
+    // The packet is consumed (moved or copied) only if successfully enqueued.
+    bool enqueue(PacketDescriptor packet);
+
+    // Dequeues a packet. Throws std::runtime_error if empty.
+    PacketDescriptor dequeue();
+
+    // Returns true if the queue is empty.
+    bool is_empty() const;
+
+    // Returns the current number of packets in the queue.
+    size_t get_current_packet_count() const;
+
+    // Returns the current total byte size of packets in the queue.
+    uint32_t get_current_byte_size() const;
+
+    // Returns the current calculated average queue size in bytes.
+    double get_average_queue_size_bytes() const;
+
+    // Gets the configured RED parameters.
+    const RedAqmParameters& get_parameters() const;
+
+private:
+    // Calculates the current drop probability based on average queue size.
+    double calculate_drop_probability() const;
+
+    // Updates the EWMA average queue size.
+    // Takes current physical queue size in bytes.
+    // 'queue_was_idle' helps in one EWMA variant: avg = (1-w) * avg + w * current OR avg = current if idle.
+    // For RED, typically avg = (1-w)*avg + w*current_physical_size always when queue is sampled (e.g. on packet arrival).
+    void update_average_queue_size();
+
+
+    std::deque<PacketDescriptor> packet_buffer_; // Using std::deque for efficient front/back access
+    RedAqmParameters params_;
+    double average_queue_size_bytes_ = 0.0;
+    uint32_t current_total_bytes_ = 0; // Current actual total bytes in queue
+
+    // For RED's count since last drop (used to smooth drop probability over time)
+    // This makes RED less bursty in its drops.
+    int packets_since_last_drop_ = 0;
+
+    // Random number generation for probabilistic drop (to be added in .cpp)
+    // Needs to be mutable if used in const calculate_drop_probability, or make that non-const.
+    // For now, keep calculate_drop_probability const, implying random generation is handled carefully.
+    // A common approach is to have a non-const "should_drop_packet" method that uses it.
+    // Or, pass a random generator reference.
+    // For simplicity in header, we omit its declaration here, will be in .cpp.
+    // mutable std::mt19937 random_generator_;
+    // mutable std::uniform_real_distribution<double> probability_distribution_;
+};
+
+} // namespace scheduler
+} // namespace hqts
+
+#endif // HQTS_SCHEDULER_AQM_QUEUE_H_

--- a/hqts/src/CMakeLists.txt
+++ b/hqts/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(hqts_core STATIC
     scheduler/wrr_scheduler.cpp             # Added
     scheduler/drr_scheduler.cpp             # Added
     scheduler/hfsc_scheduler.cpp            # Added
+    scheduler/aqm_queue.cpp                 # Added
 
     # Policy components (if any .cpp files existed, e.g. policy_tree.cpp)
     # policy/policy_tree.cpp

--- a/hqts/src/scheduler/aqm_queue.cpp
+++ b/hqts/src/scheduler/aqm_queue.cpp
@@ -1,0 +1,144 @@
+#include "hqts/scheduler/aqm_queue.h"
+#include <random>      // For std::mt19937, std::uniform_real_distribution
+#include <algorithm>   // For std::max, std::min
+#include <cmath>       // For std::pow, not strictly needed for linear prob
+#include <chrono>      // For seeding random generator
+#include <string>      // For std::to_string in error messages (though not used in this version)
+
+namespace hqts {
+namespace scheduler {
+
+// Constructor
+RedAqmQueue::RedAqmQueue(const RedAqmParameters& params)
+    : params_(params),
+      average_queue_size_bytes_(0.0),
+      current_total_bytes_(0),
+      packets_since_last_drop_(0),
+      // Seed the random number generator. Using system clock for non-deterministic behavior.
+      // For deterministic testing, a fixed seed could be used.
+      random_generator_(static_cast<unsigned int>(std::chrono::system_clock::now().time_since_epoch().count())),
+      probability_distribution_(0.0, 1.0) {}
+
+// Private helper: Updates EWMA average queue size
+// This is called *before* a drop decision for an arriving packet, using current_total_bytes_ (state before arrival).
+// Or *after* a packet is dequeued, using current_total_bytes_ (state after departure).
+void RedAqmQueue::update_average_queue_size() {
+    // Standard EWMA: avg = (1-w)*avg + w*sample
+    // Sample is the current instantaneous queue size (current_total_bytes_)
+    average_queue_size_bytes_ = (1.0 - params_.ewma_weight) * average_queue_size_bytes_ +
+                                params_.ewma_weight * static_cast<double>(current_total_bytes_);
+}
+
+// Private helper: Calculates base drop probability (p_b)
+double RedAqmQueue::calculate_drop_probability() const {
+    if (average_queue_size_bytes_ < params_.min_threshold_bytes) {
+        return 0.0;
+    } else if (average_queue_size_bytes_ >= params_.max_threshold_bytes) {
+        // When avg is at or beyond max_th, base probability is max_p
+        return params_.max_probability;
+    } else {
+        // Linear interpolation between min_th and max_th
+        double factor = (average_queue_size_bytes_ - params_.min_threshold_bytes) /
+                        (params_.max_threshold_bytes - params_.min_threshold_bytes);
+        return factor * params_.max_probability;
+    }
+}
+
+// Public method: Enqueue
+bool RedAqmQueue::enqueue(PacketDescriptor packet) {
+    // 1. Update average queue size based on state *before* this packet arrives.
+    update_average_queue_size();
+
+    // 2. Check physical capacity first (absolute tail drop if full)
+    if (current_total_bytes_ + packet.packet_length_bytes > params_.queue_capacity_bytes) {
+        // Physical queue overflow, packet is dropped.
+        // RED counters (like packets_since_last_drop_) are typically not reset for physical drops,
+        // as these are not probabilistic RED drops.
+        return false;
+    }
+
+    // 3. Calculate base drop probability (p_b)
+    double p_b = calculate_drop_probability();
+    double final_drop_prob = 0.0;
+
+    if (p_b > 0.0) { // Only apply gentle RED if base probability is non-zero
+        // Apply "gentle" RED modification using packets_since_last_drop_
+        // dp = p_b / (1 - count * p_b)
+        // This increases drop probability as count increases.
+        double denominator = 1.0 - static_cast<double>(packets_since_last_drop_) * p_b;
+        if (denominator <= 1e-9) { // Avoid division by zero or very small numbers; effectively means prob is 1
+            final_drop_prob = 1.0;
+        } else {
+            final_drop_prob = p_b / denominator;
+        }
+        // Ensure probability does not exceed 1.0 due to formula artifacts, though max_p should cap p_b.
+        // The formula for p_b already caps it at params_.max_probability.
+        // However, the gentle RED adjustment can push it higher.
+        // Some RED variants cap the final_drop_prob at 1.0 or a slightly higher max_p (e.g. 2*max_p)
+        final_drop_prob = std::min(final_drop_prob, 1.0);
+    }
+    // If p_b is 0.0, final_drop_prob remains 0.0.
+
+
+    // 4. Probabilistic drop decision
+    if (final_drop_prob > 0.0 && probability_distribution_(random_generator_) < final_drop_prob) {
+        // Packet dropped by RED
+        packets_since_last_drop_ = 0;
+        return false;
+    }
+
+    // 5. If not dropped, enqueue the packet
+    packets_since_last_drop_++;
+    current_total_bytes_ += packet.packet_length_bytes; // Update before pushing for consistency if packet had 0 length
+    packet_buffer_.push_back(std::move(packet));
+    // Note: If EWMA was to be updated *after* enqueue reflecting the new size, it would be called here again.
+    // However, RED typically uses avg queue size *seen by arriving packet*.
+    return true;
+}
+
+// Public method: Dequeue
+PacketDescriptor RedAqmQueue::dequeue() {
+    if (is_empty()) {
+        throw std::runtime_error("RedAqmQueue: Queue is empty, cannot dequeue.");
+    }
+
+    PacketDescriptor packet = packet_buffer_.front();
+    packet_buffer_.pop_front();
+    current_total_bytes_ -= packet.packet_length_bytes;
+
+    // Update average queue size after a packet departs.
+    // This keeps the average fresh for subsequent enqueue operations.
+    // Some RED variants might only update EWMA on enqueue.
+    // However, updating on dequeue as well gives a more responsive average.
+    update_average_queue_size();
+
+    return packet;
+}
+
+// Public method: is_empty
+bool RedAqmQueue::is_empty() const {
+    return packet_buffer_.empty();
+}
+
+// Public method: get_current_packet_count
+size_t RedAqmQueue::get_current_packet_count() const {
+    return packet_buffer_.size();
+}
+
+// Public method: get_current_byte_size
+uint32_t RedAqmQueue::get_current_byte_size() const {
+    return current_total_bytes_;
+}
+
+// Public method: get_average_queue_size_bytes
+double RedAqmQueue::get_average_queue_size_bytes() const {
+    return average_queue_size_bytes_;
+}
+
+// Public method: get_parameters
+const RedAqmParameters& RedAqmQueue::get_parameters() const {
+    return params_;
+}
+
+} // namespace scheduler
+} // namespace hqts

--- a/hqts/tests/CMakeLists.txt
+++ b/hqts/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(run_hqts_tests
     unit/scheduler/test_wrr_scheduler.cpp             # Added
     unit/scheduler/test_drr_scheduler.cpp             # Added
     unit/scheduler/test_hfsc_scheduler.cpp            # Added
+    unit/scheduler/test_aqm_queue.cpp                 # Added
     # Add new test_*.cpp files here as they are created
 )
 

--- a/hqts/tests/unit/scheduler/test_aqm_queue.cpp
+++ b/hqts/tests/unit/scheduler/test_aqm_queue.cpp
@@ -1,0 +1,282 @@
+#include "gtest/gtest.h"
+#include "hqts/scheduler/aqm_queue.h"
+#include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
+#include "hqts/core/flow_context.h"          // For core::FlowId (used in PacketDescriptor)
+
+#include <vector>
+#include <numeric>   // For std::accumulate
+#include <cmath>     // For std::abs, std::pow
+#include <stdexcept> // For std::invalid_argument etc.
+
+namespace hqts {
+namespace scheduler {
+
+// Helper to create a PacketDescriptor for AQM tests. Priority field is not used by RedAqmQueue.
+PacketDescriptor createAqmTestPacket(core::FlowId flow_id, uint32_t length, size_t payload_size = 0) {
+    return PacketDescriptor(flow_id, length, 0 /* priority unused */, payload_size);
+}
+
+// Default parameters for many tests, can be overridden
+RedAqmParameters defaultRedParams(
+    uint32_t capacity_pkts = 100, uint32_t pkt_size = 100, // For byte conversion
+    double min_thresh_factor = 0.2,
+    double max_thresh_factor = 0.6,
+    double max_p = 0.1,
+    double ewma_w = 0.002) {
+    uint32_t capacity_bytes = capacity_pkts * pkt_size;
+    return RedAqmParameters(
+        static_cast<uint32_t>(capacity_bytes * min_thresh_factor),
+        static_cast<uint32_t>(capacity_bytes * max_thresh_factor),
+        max_p,
+        ewma_w,
+        capacity_bytes
+    );
+}
+
+
+TEST(RedAqmQueueTest, ConstructorAndParameterValidation) {
+    // Valid parameters
+    ASSERT_NO_THROW(RedAqmParameters(1000, 2000, 0.1, 0.002, 3000));
+
+    // Invalid: min_threshold >= max_threshold
+    ASSERT_THROW(RedAqmParameters(2000, 1000, 0.1, 0.002, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 1000, 0.1, 0.002, 3000), std::invalid_argument);
+
+    // Invalid: max_threshold > capacity
+    ASSERT_THROW(RedAqmParameters(1000, 3001, 0.1, 0.002, 3000), std::invalid_argument);
+
+    // Invalid: zero thresholds or capacity
+    ASSERT_THROW(RedAqmParameters(0, 2000, 0.1, 0.002, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 0, 0.1, 0.002, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.1, 0.002, 0), std::invalid_argument);
+
+    // Invalid: ewma_weight
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.1, 0.0, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.1, 1.0, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.1, -0.1, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.1, 1.1, 3000), std::invalid_argument);
+
+    // Invalid: max_probability
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 0.0, 0.002, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, -0.1, 0.002, 3000), std::invalid_argument);
+    ASSERT_THROW(RedAqmParameters(1000, 2000, 1.1, 0.002, 3000), std::invalid_argument);
+
+    RedAqmParameters params = defaultRedParams();
+    RedAqmQueue queue(params);
+    ASSERT_TRUE(queue.is_empty());
+    ASSERT_EQ(queue.get_current_packet_count(), 0);
+    ASSERT_EQ(queue.get_current_byte_size(), 0);
+    ASSERT_DOUBLE_EQ(queue.get_average_queue_size_bytes(), 0.0);
+
+    const RedAqmParameters& retrieved_params = queue.get_parameters();
+    ASSERT_EQ(retrieved_params.min_threshold_bytes, params.min_threshold_bytes);
+}
+
+TEST(RedAqmQueueTest, EnqueueDequeueEmpty) {
+    RedAqmQueue queue(defaultRedParams());
+    PacketDescriptor p1 = createAqmTestPacket(1, 100);
+
+    ASSERT_TRUE(queue.enqueue(p1));
+    ASSERT_FALSE(queue.is_empty());
+    ASSERT_EQ(queue.get_current_packet_count(), 1);
+    ASSERT_EQ(queue.get_current_byte_size(), 100);
+
+    PacketDescriptor p_out = queue.dequeue();
+    ASSERT_EQ(p_out.flow_id, p1.flow_id);
+    ASSERT_EQ(p_out.packet_length_bytes, p1.packet_length_bytes);
+
+    ASSERT_TRUE(queue.is_empty());
+    ASSERT_EQ(queue.get_current_packet_count(), 0);
+    ASSERT_EQ(queue.get_current_byte_size(), 0);
+    ASSERT_THROW(queue.dequeue(), std::runtime_error);
+}
+
+TEST(RedAqmQueueTest, PhysicalCapacityDrop) {
+    RedAqmParameters params(200, 400, 0.1, 0.002, 500); // Capacity 500 bytes
+    RedAqmQueue queue(params);
+
+    ASSERT_TRUE(queue.enqueue(createAqmTestPacket(1, 200))); // total 200
+    ASSERT_TRUE(queue.enqueue(createAqmTestPacket(2, 200))); // total 400
+    ASSERT_EQ(queue.get_current_byte_size(), 400);
+
+    // This packet (150B) should exceed capacity (400+150 > 500)
+    ASSERT_FALSE(queue.enqueue(createAqmTestPacket(3, 150)));
+    ASSERT_EQ(queue.get_current_byte_size(), 400); // Still 400
+    ASSERT_EQ(queue.get_current_packet_count(), 2);
+
+    // This packet (100B) should fit
+    ASSERT_TRUE(queue.enqueue(createAqmTestPacket(4, 100)));
+    ASSERT_EQ(queue.get_current_byte_size(), 500);
+    ASSERT_EQ(queue.get_current_packet_count(), 3);
+
+    // This packet (1B) should not fit
+    ASSERT_FALSE(queue.enqueue(createAqmTestPacket(5, 1)));
+    ASSERT_EQ(queue.get_current_byte_size(), 500);
+}
+
+TEST(RedAqmQueueTest, EwmaAverageCalculation) {
+    // Params: min=200, max=800, cap=1000, weight=0.5
+    RedAqmParameters params(200, 800, 0.1, 0.5, 1000);
+    RedAqmQueue queue(params);
+    double current_avg;
+
+    // Initial: avg=0, total_bytes=0
+    // Enqueue P1 (100B)
+    //  update_avg (uses total_bytes=0): avg = (1-0.5)*0 + 0.5*0 = 0.
+    //  (P1 not dropped). Add P1. total_bytes=100.
+    queue.enqueue(createAqmTestPacket(1, 100));
+    current_avg = queue.get_average_queue_size_bytes(); // This avg is *after* first update_avg for P1
+    ASSERT_DOUBLE_EQ(current_avg, 0.0); // Avg calc based on queue *before* P1
+
+    // Enqueue P2 (100B)
+    //  update_avg (uses total_bytes=100): avg = (1-0.5)*0 + 0.5*100 = 50.
+    //  (P2 not dropped). Add P2. total_bytes=200.
+    queue.enqueue(createAqmTestPacket(2, 100));
+    current_avg = queue.get_average_queue_size_bytes(); // Avg based on queue *before* P2
+    ASSERT_DOUBLE_EQ(current_avg, 50.0);
+
+    // Enqueue P3 (100B)
+    //  update_avg (uses total_bytes=200): avg = (1-0.5)*50 + 0.5*200 = 25 + 100 = 125.
+    //  (P3 not dropped). Add P3. total_bytes=300.
+    queue.enqueue(createAqmTestPacket(3, 100));
+    current_avg = queue.get_average_queue_size_bytes();
+    ASSERT_DOUBLE_EQ(current_avg, 125.0);
+
+    // Dequeue P1 (100B)
+    //  P1 removed. total_bytes=200.
+    //  update_avg (uses total_bytes=200): avg = (1-0.5)*125 + 0.5*200 = 62.5 + 100 = 162.5.
+    queue.dequeue();
+    current_avg = queue.get_average_queue_size_bytes();
+    ASSERT_DOUBLE_EQ(current_avg, 162.5);
+}
+
+TEST(RedAqmQueueTest, RedDropsBelowMinThreshold) {
+    // min_thresh=1000, max_thresh=2000, capacity=3000
+    RedAqmParameters params(1000, 2000, 0.1, 0.002, 3000);
+    RedAqmQueue queue(params);
+
+    int packets_enqueued = 0;
+    for (int i = 0; i < 5; ++i) { // Enqueue 5 * 100 = 500 bytes
+        if(queue.enqueue(createAqmTestPacket(i, 100))) {
+            packets_enqueued++;
+        }
+    }
+    ASSERT_EQ(packets_enqueued, 5);
+    // Avg queue size should be < 1000 (actual is 500, EWMA will be less initially)
+    ASSERT_LT(queue.get_average_queue_size_bytes(), params.min_threshold_bytes);
+    // packets_since_last_drop_ should be 5 (if internal counter accessible)
+}
+
+TEST(RedAqmQueueTest, RedDropsAtOrAboveMaxThreshold) {
+    // min=200, max=400, max_p=0.1, capacity=1000. weight=1.0 (so avg = current)
+    RedAqmParameters params(200, 400, 0.1, 1.0, 1000);
+    RedAqmQueue queue(params);
+
+    // Fill queue to average >= max_threshold
+    for(int i=0; i<4; ++i) queue.enqueue(createAqmTestPacket(i,100)); // 400 bytes
+    ASSERT_GE(queue.get_average_queue_size_bytes(), params.max_threshold_bytes);
+
+    // Now, probability p_b = max_p. Gentle RED makes actual prob higher.
+    // With count starting at 0 after a potential drop, or high if no drops.
+    // If packets_since_last_drop_ * max_p >= 1, it's a forced drop.
+    // 1 / 0.1 = 10. So after 10 successful enqueues in this state, next is guaranteed drop.
+
+    int drops = 0;
+    int attempts = 200; // Multiple packets to observe drops
+    // After filling to max_thresh, packets_since_last_drop_ is 4.
+    // p_b = 0.1.
+    // Pkt 5: count=4. den=1-4*0.1=0.6. dp=0.1/0.6 = 0.166.
+    // Pkt 6: count=5 (if 5 not dropped). den=1-5*0.1=0.5. dp=0.1/0.5 = 0.2.
+    // ...
+    // Pkt 10: count=9. den=1-9*0.1=0.1. dp=0.1/0.1 = 1.0. (Guaranteed drop if reached)
+
+    for (int i = 0; i < attempts; ++i) {
+        if (!queue.enqueue(createAqmTestPacket(100 + i, 10))) { // Small packets
+            drops++;
+        }
+    }
+    // Expect significant drops. The exact number is probabilistic.
+    // At least one drop should occur due to count escalating to force drop.
+    ASSERT_GT(drops, 0);
+    // More specifically, after enough non-drops, count * p_b will make denominator <=0, forcing drop.
+    // Max non-drops before forced drop: count < 1/p_b. count < 10. So at 10th attempt, drop is guaranteed.
+}
+
+
+TEST(RedAqmQueueTest, RedDropsBetweenMinMaxThreshold) {
+    // min=200, max=800 (range 600), max_p=0.1, capacity=1000. weight=1.0 (avg = current)
+    RedAqmParameters params(200, 800, 0.1, 1.0, 1000);
+    RedAqmQueue queue(params);
+
+    // Fill queue to avg = 500 (midpoint: (200+800)/2)
+    for(int i=0; i<5; ++i) queue.enqueue(createAqmTestPacket(i,100)); // 500 bytes
+    ASSERT_DOUBLE_EQ(queue.get_average_queue_size_bytes(), 500.0);
+
+    // At avg=500, p_b = max_p * (500-200)/(800-200) = 0.1 * (300/600) = 0.1 * 0.5 = 0.05
+    // packets_since_last_drop_ is 5.
+    // dp for next packet = 0.05 / (1 - 5 * 0.05) = 0.05 / (1 - 0.25) = 0.05 / 0.75 = ~0.0667
+
+    int drops = 0;
+    int attempts = 1000;
+    for (int i = 0; i < attempts; ++i) {
+        // Enqueue small packets to minimally change average, to test prob at this level
+        if (!queue.enqueue(createAqmTestPacket(100 + i, 1))) {
+            drops++;
+        }
+        // To keep avg somewhat stable, dequeue if too full (not ideal for this test)
+        if (queue.get_current_byte_size() > 550) queue.dequeue();
+    }
+    // Expected drops around attempts * effective_prob. This is very rough.
+    // For p_b=0.05, count=0 -> dp=0.05. For count=10, den=1-10*0.05=0.5, dp=0.1
+    // The average dp will be higher than p_b.
+    ASSERT_GT(drops, attempts * 0.05 * 0.5); // Expect at least some drops, very roughly > half of base prob
+    ASSERT_LT(drops, attempts * 0.2); // And not excessively high, very roughly < 2 * escalated prob
+}
+
+TEST(RedAqmQueueTest, GentleRedEffectOfCount) {
+    // min=100, max=1100 (range 1000), max_p=0.1, capacity=2000. weight=1.0
+    RedAqmParameters params(100, 1100, 0.1, 1.0, 2000);
+    RedAqmQueue queue(params);
+
+    // Fill to avg = 600 (midpoint of min/max, so p_b = 0.05)
+    for(int i=0; i<6; ++i) queue.enqueue(createAqmTestPacket(i,100)); // 600 bytes
+    ASSERT_DOUBLE_EQ(queue.get_average_queue_size_bytes(), 600.0);
+    // At this point, packets_since_last_drop_ = 6.
+    // p_b = 0.1 * (600-100)/(1100-100) = 0.1 * 500/1000 = 0.05.
+
+    // Next enqueue attempt:
+    // count = 6. denom = 1 - 6 * 0.05 = 1 - 0.3 = 0.7.
+    // dp = 0.05 / 0.7 = ~0.0714.
+
+    // If we enqueue successfully for a few more times:
+    // count=7: dp = 0.05 / (1-7*0.05) = 0.05 / 0.65 = ~0.0769
+    // count=8: dp = 0.05 / (1-8*0.05) = 0.05 / 0.6 = ~0.0833
+    // count=9: dp = 0.05 / (1-9*0.05) = 0.05 / 0.55 = ~0.0909
+    // count=10: dp = 0.05 / (1-10*0.05) = 0.05 / 0.5 = 0.1
+    // count=19: dp = 0.05 / (1-19*0.05) = 0.05 / 0.05 = 1.0 (guaranteed drop)
+
+    bool dropped_at_high_count = false;
+    for (int i = 0; i < 20; ++i) { // Try to enqueue 20 more packets
+        if (!queue.enqueue(createAqmTestPacket(100+i, 10))) { // Small packets
+            dropped_at_high_count = true;
+            ASSERT_GE(i, 9); // Should take at least 10-ish tries from count=6 to force drop if random is unlucky
+            ASSERT_LE(i, 13); // (6 existing + 13 new = 19) -> guaranteed drop at 19th non-drop since last.
+            break;
+        }
+        if (i == 13 && !dropped_at_high_count) { // If by 13th new packet (total count 19) no drop, fail
+             // This means packets_since_last_drop_ would be 6+13 = 19.
+             // Denom = 1 - 19 * 0.05 = 1 - 0.95 = 0.05. dp = 0.05 / 0.05 = 1.0
+             // So, it MUST have dropped by now.
+        }
+    }
+    ASSERT_TRUE(dropped_at_high_count); // Ensure a drop eventually happened due to escalating probability
+
+    // Check reset of packets_since_last_drop_
+    // This requires internal access or a way to guarantee a drop then check.
+    // The above loop implies it if it dropped then continued.
+    // For a more direct test, one might need a friend class or specific test methods.
+}
+
+
+} // namespace scheduler
+} // namespace hqts


### PR DESCRIPTION
This commit introduces an Active Queue Management (AQM) mechanism, specifically Random Early Detection (RED), through the `RedAqmQueue` class. This component is designed to help prevent network congestion by probabilistically dropping packets before a queue becomes physically full.

Key features and components:
1.  `RedAqmParameters` (`scheduler/aqm_queue.h`):
    - A struct to hold all configuration parameters for a RED queue, including minimum and maximum thresholds for average queue size, maximum drop probability, EWMA weight for average calculation, and physical queue capacity.
    - Includes constructor validation for parameter consistency.

2.  `RedAqmQueue` Class (`scheduler/aqm_queue.h`, `scheduler/aqm_queue.cpp`):
    - Implements a queue that uses RED logic for packet admission.
    - **EWMA Average Queue Size**: Tracks the average queue size in bytes using an Exponential Weighted Moving Average (EWMA). The average is updated upon packet enqueue (reflecting state before arrival for drop decision) and dequeue (reflecting state after departure).
    - **RED Drop Logic**:
        - No drops if average queue size is below `min_threshold`.
        - Probabilistic drops if average is between `min_threshold` and `max_threshold`. The base drop probability increases linearly. - Drops with `max_probability` (adjusted by `count`) if average is at or above `max_threshold`.
    - **Gentle RED**: Incorporates a `packets_since_last_drop_` counter to adjust the drop probability, making it more aggressive as more packets are admitted without a drop, as per standard "gentle" RED variants.
    - **Physical Capacity**: Drops packets if the physical byte capacity of the queue would be exceeded (tail drop), which takes precedence over RED drops.
    - Provides methods for enqueue (returns true if packet accepted, false if dropped), dequeue, and inspection of current/average queue sizes and packet counts.
    - Uses a `std::deque` for internal packet storage and `std::mt19937` for random number generation for probabilistic drops.

3.  Unit Tests (`tests/unit/scheduler/test_aqm_queue.cpp`):
    - Comprehensive Gtests were added to validate: - Constructor and parameter validation for `RedAqmParameters` and `RedAqmQueue`. - Basic enqueue/dequeue operations and physical capacity limits. - Correctness of the EWMA average queue size calculation. - Various RED drop scenarios: below min threshold (no drops), between min/max thresholds (probabilistic drops), and at/above max threshold. - The effect of the `packets_since_last_drop_` counter on drop probability ("gentle RED").

4.  CMake Integration:
    - Updated `src/CMakeLists.txt` and `tests/CMakeLists.txt` to include the new `aqm_queue.cpp` and `test_aqm_queue.cpp` files in the build process.

This `RedAqmQueue` provides a foundational component for implementing more sophisticated congestion avoidance strategies within the HQTS project.