### PR TITLE
feat: Implement RedAqmQueue with PRNG fix

### DIFF
--- a/hqts/include/hqts/scheduler/aqm_queue.h
+++ b/hqts/include/hqts/scheduler/aqm_queue.h
@@ -8,6 +8,7 @@
 #include <string> // For potential error messages
 #include <stdexcept> // For exceptions
 #include <chrono> // For time if needed for EWMA weight calculation or stats
+#include <random> // For std::mt19937, std::uniform_real_distribution
 
 namespace hqts {
 namespace scheduler {
@@ -86,8 +87,11 @@ private:
     // A common approach is to have a non-const "should_drop_packet" method that uses it.
     // Or, pass a random generator reference.
     // For simplicity in header, we omit its declaration here, will be in .cpp.
-    // mutable std::mt19937 random_generator_;
-    // mutable std::uniform_real_distribution<double> probability_distribution_;
+    // mutable std::mt19937 random_generator_;  // Now declared below
+    // mutable std::uniform_real_distribution<double> probability_distribution_; // Now declared below
+
+    std::mt19937 random_generator_;
+    std::uniform_real_distribution<double> probability_distribution_;
 };
 
 } // namespace scheduler


### PR DESCRIPTION
This commit introduces the RedAqmQueue for Active Queue Management, including its implementation, unit tests, and a fix for missing PRNG member declarations.

Key features and components:
1.  `RedAqmParameters` (`scheduler/aqm_queue.h`):
    - Struct for RED configuration (thresholds, max probability, EWMA weight, capacity) with constructor validation.

2.  `RedAqmQueue` Class (`scheduler/aqm_queue.h`, `scheduler/aqm_queue.cpp`):
    - Implements RED AQM logic.
    - Tracks average queue size using EWMA.
    - Performs probabilistic packet drops based on RED algorithm, including "gentle RED" adjustments using `packets_since_last_drop_`.
    - Enforces physical queue capacity.
    - **Fix**: Declared `std::mt19937 random_generator_;` and `std::uniform_real_distribution<double> probability_distribution_;` as private members in the header and included `<random>`, resolving previous compilation errors.

3.  Unit Tests (`tests/unit/scheduler/test_aqm_queue.cpp`):
    - Comprehensive Gtests for `RedAqmQueue`, validating: - Constructor and parameter validation. - Basic operations and physical capacity limits. - EWMA calculation. - RED drop behavior across different thresholds and the "gentle RED" mechanism.

4.  CMake Integration:
    - Updated `src/CMakeLists.txt` and `tests/CMakeLists.txt` to include the new AQM files.

This `RedAqmQueue` provides a foundational component for congestion avoidance within the HQTS project.