### PR TITLE
feat: Implement Flow Classification and integrate with TrafficShaper

### DIFF
--- a/hqts/include/hqts/dataplane/flow_classifier.h
+++ b/hqts/include/hqts/dataplane/flow_classifier.h
@@ -1,0 +1,60 @@
+#ifndef HQTS_DATAPLANE_FLOW_CLASSIFIER_H_
+#define HQTS_DATAPLANE_FLOW_CLASSIFIER_H_
+
+#include "hqts/dataplane/flow_identifier.h" // For FiveTuple, FlowKey
+#include "hqts/core/flow_context.h"        // For core::FlowId, FlowContext, core::FlowTable
+#include "hqts/policy/policy_types.h"      // For policy::PolicyId
+// #include "hqts/scheduler/packet_descriptor.h" // Not directly needed if FiveTuple is passed
+
+#include <unordered_map>
+#include <mutex>    // For std::mutex and std::lock_guard
+#include <memory>   // For std::shared_ptr (not used here, but often in similar contexts)
+
+namespace hqts {
+namespace dataplane {
+
+class FlowClassifier {
+public:
+    /**
+     * @brief Constructor for FlowClassifier.
+     * @param flow_table A reference to the application's main FlowTable where FlowContexts are stored.
+     * @param default_policy_id The PolicyId to assign to newly identified flows.
+     */
+    FlowClassifier(core::FlowTable& flow_table, policy::PolicyId default_policy_id);
+
+    // FlowClassifier might be stateful and potentially shared, so manage copy/move carefully.
+    // For now, make it non-copyable and non-movable to simplify.
+    FlowClassifier(const FlowClassifier&) = delete;
+    FlowClassifier& operator=(const FlowClassifier&) = delete;
+    FlowClassifier(FlowClassifier&&) = delete;
+    FlowClassifier& operator=(FlowClassifier&&) = delete;
+
+    /**
+     * @brief Gets the FlowId for a given FiveTuple.
+     * If the flow is new, it creates a FlowId, adds a corresponding FlowContext
+     * to the FlowTable using the default_policy_id, and maps the FiveTuple to the new FlowId.
+     * @param five_tuple The 5-tuple identifying the flow.
+     * @return The core::FlowId associated with this flow.
+     */
+    core::FlowId get_or_create_flow(const FiveTuple& five_tuple);
+
+    // Convenience overload for PacketDescriptor might be added later if PacketDescriptor is enhanced
+    // to easily provide a FiveTuple or if parsing logic is integrated here.
+    // core::FlowId get_or_create_flow(const scheduler::PacketDescriptor& packet);
+
+private:
+    core::FlowTable& flow_table_; // Reference to the global flow table (stores FlowContext)
+
+    // Internal map to quickly find an existing FlowId for a given FlowKey (FiveTuple)
+    std::unordered_map<FlowKey, core::FlowId> flow_key_to_flow_id_map_;
+
+    core::FlowId next_flow_id_ = 1; // Monotonically increasing counter for new FlowIds
+    policy::PolicyId default_policy_id_; // Policy to assign to new flows
+
+    std::mutex mutex_; // Mutex to protect access to flow_key_to_flow_id_map_ and next_flow_id_
+};
+
+} // namespace dataplane
+} // namespace hqts
+
+#endif // HQTS_DATAPLANE_FLOW_CLASSIFIER_H_

--- a/hqts/include/hqts/dataplane/flow_identifier.h
+++ b/hqts/include/hqts/dataplane/flow_identifier.h
@@ -1,0 +1,85 @@
+#ifndef HQTS_DATAPLANE_FLOW_IDENTIFIER_H_
+#define HQTS_DATAPLANE_FLOW_IDENTIFIER_H_
+
+#include <cstdint>
+#include <string>     // For potential future use (e.g. string IPs if needed, though not current)
+#include <functional> // For std::hash
+#include <utility>    // For std::pair (not directly used here, but often with hashing)
+
+// Forward declaration of core::FlowId is not strictly necessary here as this file
+// defines the key structure used to *look up or generate* a core::FlowId.
+// The actual core::FlowId (uint64_t) is defined in hqts/core/flow_context.h.
+
+namespace hqts {
+namespace dataplane {
+
+// Basic 5-tuple structure for flow identification.
+// In a real system, IP addresses might be represented by more complex types
+// (e.g., from a networking library, or structs that handle IPv4/IPv6).
+struct FiveTuple {
+    uint32_t source_ip;      // IPv4 source address
+    uint32_t dest_ip;        // IPv4 destination address
+    uint16_t source_port;    // Source port (TCP/UDP)
+    uint16_t dest_port;      // Destination port (TCP/UDP)
+    uint8_t protocol;       // IP protocol (e.g., IPPROTO_TCP, IPPROTO_UDP from netinet/in.h)
+
+    // Constructor with default values
+    FiveTuple(uint32_t s_ip = 0, uint32_t d_ip = 0,
+              uint16_t s_port = 0, uint16_t d_port = 0,
+              uint8_t proto = 0)
+        : source_ip(s_ip), dest_ip(d_ip),
+          source_port(s_port), dest_port(d_port), protocol(proto) {}
+
+    // Equality operator: crucial for std::unordered_map to handle hash collisions.
+    bool operator==(const FiveTuple& other) const {
+        return source_ip == other.source_ip &&
+               dest_ip == other.dest_ip &&
+               source_port == other.source_port &&
+               dest_port == other.dest_port &&
+               protocol == other.protocol;
+    }
+
+    // Optional: A less-than operator can be useful for ordered maps or sets,
+    // though not strictly required for std::unordered_map.
+    bool operator<(const FiveTuple& other) const {
+        if (source_ip != other.source_ip) return source_ip < other.source_ip;
+        if (dest_ip != other.dest_ip) return dest_ip < other.dest_ip;
+        if (source_port != other.source_port) return source_port < other.source_port;
+        if (dest_port != other.dest_port) return dest_port < other.dest_port;
+        return protocol < other.protocol;
+    }
+};
+
+// FlowKey is defined as the FiveTuple for identifying flows based on packet headers.
+using FlowKey = FiveTuple;
+
+// Note: The core::FlowId (defined in hqts/core/flow_context.h as uint64_t)
+// will be the actual identifier used as the key in the FlowTable.
+// A FlowClassifier component will be responsible for mapping a FlowKey (FiveTuple)
+// derived from a packet to a unique core::FlowId (e.g., by hashing the FlowKey
+// or using a monotonic counter for new flows).
+
+} // namespace dataplane
+} // namespace hqts
+
+// Specialization of std::hash for hqts::dataplane::FiveTuple.
+// This allows hqts::dataplane::FiveTuple (and thus FlowKey) to be used as a key
+// in std::unordered_map and std::unordered_set.
+namespace std {
+template <>
+struct hash<hqts::dataplane::FiveTuple> {
+    size_t operator()(const hqts::dataplane::FiveTuple& k) const {
+        // A common way to combine hashes for multiple fields.
+        // This specific sequence is often used (similar to Boost's hash_combine).
+        size_t seed = 0;
+        seed ^= std::hash<uint32_t>{}(k.source_ip) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint32_t>{}(k.dest_ip) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint16_t>{}(k.source_port) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint16_t>{}(k.dest_port) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= std::hash<uint8_t>{}(k.protocol) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
+} // namespace std
+
+#endif // HQTS_DATAPLANE_FLOW_IDENTIFIER_H_

--- a/hqts/src/CMakeLists.txt
+++ b/hqts/src/CMakeLists.txt
@@ -9,12 +9,14 @@ add_library(hqts_core STATIC
     scheduler/drr_scheduler.cpp             # Added
     scheduler/hfsc_scheduler.cpp            # Added
     scheduler/aqm_queue.cpp                 # Added
+    core/traffic_shaper.cpp                 # Added (was missing from explicit list)
+    dataplane/flow_classifier.cpp           # Added
 
     # Policy components (if any .cpp files existed, e.g. policy_tree.cpp)
     # policy/policy_tree.cpp
 
     # Dataplane components (if any .cpp files existed, e.g. flow_table.cpp)
-    # dataplane/flow_table.cpp
+    # dataplane/flow_table.cpp # flow_table.h is header only for now
 
     # Main application logic (if main.cpp is part of the library)
     # If main.cpp is to be a separate executable, it should be in add_executable()

--- a/hqts/src/dataplane/flow_classifier.cpp
+++ b/hqts/src/dataplane/flow_classifier.cpp
@@ -1,0 +1,75 @@
+#include "hqts/dataplane/flow_classifier.h"
+#include <stdexcept> // For std::runtime_error (though not used in current version)
+#include <string>    // For std::to_string (not used in current version)
+
+namespace hqts {
+namespace dataplane {
+
+FlowClassifier::FlowClassifier(core::FlowTable& ft, policy::PolicyId default_pid)
+    : flow_table_(ft),
+      default_policy_id_(default_pid),
+      next_flow_id_(1) { // Start FlowIds from 1 (0 might be reserved)
+
+    // A check could be added here to ensure default_policy_id_ is valid,
+    // but FlowClassifier doesn't have direct access to PolicyTree to verify.
+    // This responsibility would typically lie with the system initializing the FlowClassifier.
+    // For example, if policy_id 0 is invalid unless it's a special NO_POLICY_ID marker.
+    // if (default_policy_id_ == 0 && default_policy_id_ != policy::NO_PARENT_POLICY_ID) { // Example check
+    //     throw std::invalid_argument("FlowClassifier: Invalid default_policy_id provided.");
+    // }
+}
+
+core::FlowId FlowClassifier::get_or_create_flow(const FiveTuple& five_tuple) {
+    std::lock_guard<std::mutex> lock(mutex_); // Thread-safe access to shared members
+
+    // Check if FlowKey (FiveTuple) already exists in our map
+    auto it = flow_key_to_flow_id_map_.find(five_tuple);
+    if (it != flow_key_to_flow_id_map_.end()) {
+        // Found existing flow, return its FlowId
+        return it->second;
+    }
+
+    // New flow detected
+    core::FlowId new_id = next_flow_id_++;
+    flow_key_to_flow_id_map_[five_tuple] = new_id; // Store mapping from FiveTuple to new FlowId
+
+    // Create a new FlowContext for this flow and add it to the global FlowTable.
+    // The FlowContext constructor needs: FlowId, PolicyId, QueueId, DropPolicy.
+    // For a new flow, we use the default_policy_id_.
+    // Default QueueId and DropPolicy need to be defined. These might ideally come from
+    // inspecting the default_policy_id_ in the PolicyTree, or be system-wide defaults.
+    // For this implementation, we'll use simple placeholder defaults.
+    core::QueueId default_initial_queue_id = 0; // Placeholder - might be derived from policy
+    core::DropPolicy default_initial_drop_policy = core::DropPolicy::TAIL_DROP; // Placeholder
+
+    core::FlowContext new_flow_context(new_id, default_policy_id_,
+                                       default_initial_queue_id, default_initial_drop_policy);
+
+    // Optionally, store the FlowKey (FiveTuple) in FlowContext if FlowContext is extended to hold it.
+    // Example: new_flow_context.flow_key = five_tuple;
+
+    auto emplace_result = flow_table_.emplace(new_id, new_flow_context);
+    if (!emplace_result.second) {
+        // This would be highly unusual if next_flow_id_ is strictly monotonic and unique.
+        // It implies a FlowId collision in the global flow_table_, which should not happen.
+        // Handle error: throw, log, or overwrite. For now, let's assume this won't fail.
+        // (Could happen if FlowTable keys are not managed solely by this classifier's next_flow_id_)
+    }
+
+    return new_id;
+}
+
+// Placeholder for PacketDescriptor overload - commented out in header
+/*
+core::FlowId FlowClassifier::get_or_create_flow(const scheduler::PacketDescriptor& packet) {
+    // 1. Extract FiveTuple from packet (requires packet parsing logic or richer PacketDescriptor)
+    //    FiveTuple five_tuple = ... ;
+    // 2. Call the primary get_or_create_flow
+    //    return get_or_create_flow(five_tuple);
+
+    throw std::logic_error("get_or_create_flow from PacketDescriptor is not yet implemented.");
+}
+*/
+
+} // namespace dataplane
+} // namespace hqts

--- a/hqts/tests/CMakeLists.txt
+++ b/hqts/tests/CMakeLists.txt
@@ -32,6 +32,8 @@ add_executable(run_hqts_tests
     unit/scheduler/test_drr_scheduler.cpp             # Added
     unit/scheduler/test_hfsc_scheduler.cpp            # Added
     unit/scheduler/test_aqm_queue.cpp                 # Added
+    unit/core/test_traffic_shaper.cpp                 # Added (was missing from explicit list)
+    unit/dataplane/test_flow_classifier.cpp           # Added
     # Add new test_*.cpp files here as they are created
 )
 

--- a/hqts/tests/unit/dataplane/test_flow_classifier.cpp
+++ b/hqts/tests/unit/dataplane/test_flow_classifier.cpp
@@ -1,0 +1,150 @@
+#include "gtest/gtest.h"
+#include "hqts/dataplane/flow_classifier.h"
+#include "hqts/dataplane/flow_identifier.h" // For FiveTuple
+#include "hqts/core/flow_context.h"        // For FlowTable, FlowContext, FlowId
+#include "hqts/policy/policy_types.h"      // For PolicyId
+
+#include <thread> // For thread safety tests
+#include <vector>
+#include <set>    // For checking uniqueness of FlowIds
+#include <memory> // For std::unique_ptr
+
+namespace hqts {
+namespace dataplane {
+
+class FlowClassifierTest : public ::testing::Test {
+protected:
+    core::FlowTable test_flow_table_;
+    // Using a distinct PolicyId for default to avoid clashes with other test policies if any were global
+    static const policy::PolicyId DEFAULT_POLICY_ID = 199;
+    std::unique_ptr<FlowClassifier> classifier_;
+
+    void SetUp() override {
+        test_flow_table_.clear();
+        // A new classifier instance for each test ensures next_flow_id_ starts fresh (from 1).
+        classifier_ = std::make_unique<FlowClassifier>(test_flow_table_, DEFAULT_POLICY_ID);
+    }
+
+    void TearDown() override {
+        // classifier_ unique_ptr will handle cleanup
+    }
+};
+
+// Define static const member
+const policy::PolicyId FlowClassifierTest::DEFAULT_POLICY_ID;
+
+TEST_F(FlowClassifierTest, CreateNewFlow) {
+    FiveTuple tuple1(192, 168, 1, 1, 10, 20, 6); // src_ip, dest_ip, src_port, dest_port, proto
+
+    core::FlowId fid1 = classifier_->get_or_create_flow(tuple1);
+    ASSERT_NE(fid1, 0); // Assuming FlowId 0 is invalid or reserved
+    ASSERT_EQ(test_flow_table_.count(fid1), 1);
+
+    const core::FlowContext& ctx1 = test_flow_table_.at(fid1);
+    ASSERT_EQ(ctx1.flow_id, fid1);
+    ASSERT_EQ(ctx1.policy_id, DEFAULT_POLICY_ID);
+    // Check default queue_id and drop_policy as set by FlowClassifier's current implementation
+    ASSERT_EQ(ctx1.queue_id, 0);
+    ASSERT_EQ(ctx1.drop_policy, core::DropPolicy::TAIL_DROP);
+}
+
+TEST_F(FlowClassifierTest, GetExistingFlow) {
+    FiveTuple tuple1(192, 168, 1, 1, 10, 20, 6);
+    core::FlowId fid1_initial = classifier_->get_or_create_flow(tuple1);
+    ASSERT_EQ(test_flow_table_.size(), 1);
+
+    core::FlowId fid1_retrieved = classifier_->get_or_create_flow(tuple1);
+    ASSERT_EQ(fid1_retrieved, fid1_initial);
+    ASSERT_EQ(test_flow_table_.size(), 1); // No new FlowContext should be created
+}
+
+TEST_F(FlowClassifierTest, MultipleDistinctFlows) {
+    FiveTuple tuple1(192, 168, 1, 1, 10, 20, 6);
+    FiveTuple tuple2(192, 168, 1, 2, 30, 40, 17); // Different dest_ip, ports, proto
+    FiveTuple tuple3(10, 0, 0, 1, 100, 200, 6);   // Different src_ip
+
+    core::FlowId fid1 = classifier_->get_or_create_flow(tuple1);
+    core::FlowId fid2 = classifier_->get_or_create_flow(tuple2);
+    core::FlowId fid3 = classifier_->get_or_create_flow(tuple3);
+
+    ASSERT_NE(fid1, fid2);
+    ASSERT_NE(fid1, fid3);
+    ASSERT_NE(fid2, fid3);
+
+    ASSERT_EQ(test_flow_table_.size(), 3);
+    ASSERT_TRUE(test_flow_table_.count(fid1));
+    ASSERT_TRUE(test_flow_table_.count(fid2));
+    ASSERT_TRUE(test_flow_table_.count(fid3));
+}
+
+TEST_F(FlowClassifierTest, FlowIdUniqueness) {
+    std::vector<FiveTuple> tuples;
+    const int num_unique_tuples = 100;
+    for (int i = 0; i < num_unique_tuples; ++i) {
+        // Create distinct 5-tuples by varying source port
+        tuples.emplace_back(192, 168, 1, 1, static_cast<uint16_t>(1000 + i), 80, 6);
+    }
+
+    std::set<core::FlowId> generated_flow_ids;
+    for (const auto& tuple : tuples) {
+        generated_flow_ids.insert(classifier_->get_or_create_flow(tuple));
+    }
+
+    ASSERT_EQ(generated_flow_ids.size(), static_cast<size_t>(num_unique_tuples));
+    ASSERT_EQ(test_flow_table_.size(), static_cast<size_t>(num_unique_tuples));
+}
+
+TEST_F(FlowClassifierTest, ThreadSafety) {
+    std::vector<std::thread> threads;
+    const int num_threads = 10;
+    const int iterations_per_thread = 100;
+    std::set<core::FlowId> all_generated_ids;
+    std::mutex set_mutex;
+
+    FiveTuple common_tuple(10, 20, 30, 40, 50, 60, 6);
+    // The first thread to grab the lock for common_tuple will create it. Others will get existing.
+    // No need to pre-fetch common_fid_expected before threads, classifier should handle the race.
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() { // Capture i by value for unique tuple generation
+            std::vector<core::FlowId> local_ids;
+            for (int j = 0; j < iterations_per_thread; ++j) {
+                if (j % 10 == 0) {
+                    local_ids.push_back(classifier_->get_or_create_flow(common_tuple));
+                } else {
+                    FiveTuple unique_tuple(1,1,1,1, static_cast<uint16_t>(i), static_cast<uint16_t>(j), 17);
+                    local_ids.push_back(classifier_->get_or_create_flow(unique_tuple));
+                }
+            }
+            // Lock only when modifying shared set
+            std::lock_guard<std::mutex> lock(set_mutex);
+            for (core::FlowId id : local_ids) {
+                all_generated_ids.insert(id);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Fetch the ID for the common_tuple one last time to confirm it's stable and was created.
+    core::FlowId common_fid_final = classifier_->get_or_create_flow(common_tuple);
+    ASSERT_TRUE(all_generated_ids.count(common_fid_final));
+
+    // Calculate expected number of unique FlowIds:
+    // 1 (for common_tuple) + (num_threads * number of unique tuples generated per thread)
+    size_t unique_tuples_per_thread = 0;
+     for(int j=0; j < iterations_per_thread; ++j) {
+        if (j % 10 != 0) { // This condition identifies when unique tuples are made
+            unique_tuples_per_thread++;
+        }
+     }
+    size_t expected_unique_flows = 1 + num_threads * unique_tuples_per_thread;
+
+    ASSERT_EQ(all_generated_ids.size(), expected_unique_flows);
+    ASSERT_EQ(test_flow_table_.size(), expected_unique_flows);
+}
+
+} // namespace dataplane
+} // namespace hqts


### PR DESCRIPTION
This commit introduces packet classification capabilities, enabling the system to identify network flows based on 5-tuples and associate them with policies for subsequent traffic shaping and scheduling.

Key components and changes:
1.  Flow Identification Structures (`dataplane/flow_identifier.h`):
    - Defined `FiveTuple` struct (source/dest IP, source/dest port, protocol) to represent flow characteristics.
    - Defined `FlowKey` as a type alias for `FiveTuple`.
    - Provided `std::hash<FiveTuple>` specialization for using `FlowKey` in unordered maps.

2.  Flow Classifier (`dataplane/flow_classifier.h/cpp`):
    - Implemented `FlowClassifier` class to map `FiveTuple` instances to unique `core::FlowId`s.
    - The `get_or_create_flow()` method:
        - Performs a lookup for an existing flow based on the 5-tuple.
        - If a new flow is detected, it generates a new `core::FlowId`, creates a corresponding `core::FlowContext` (assigning a configurable default policy ID), and stores this context in the global `FlowTable`. - Includes `std::mutex` for thread-safe operations on its internal map and ID generator.
    - The class is designed to be non-copyable and non-movable.

3.  Integration with TrafficShaper (`core/traffic_shaper.h/cpp`):
    - `TrafficShaper` constructor now takes references to `FlowClassifier` and `FlowTable`.
    - `TrafficShaper::process_packet()` method signature changed to accept `const dataplane::FiveTuple&` instead of `const core::FlowContext&`.
    - `process_packet()` now first calls `FlowClassifier::get_or_create_flow()` to obtain the `FlowId` and ensure a `FlowContext` exists. It then retrieves this context from the `FlowTable` to apply policy and token bucket logic.
    - `PacketDescriptor::flow_id` is now set within `TrafficShaper::process_packet` after classification.

4.  Unit Tests:
    - Added comprehensive tests for `FlowClassifier` (`tests/unit/dataplane/test_flow_classifier.cpp`), covering new flow creation, retrieval of existing flows, FlowID uniqueness, and thread safety.
    - Updated `TrafficShaper` tests (`tests/unit/core/test_traffic_shaper.cpp`) to reflect its new API (taking `FiveTuple`) and its use of `FlowClassifier` and `FlowTable`. Test setup now includes these components and helper methods to associate specific 5-tuples with test policies.

5.  CMake Updates:
    - `src/CMakeLists.txt` and `tests/CMakeLists.txt` updated to include the new flow classification source files and test files.

This work provides a critical frontend component for the HQTS system, enabling it to identify and manage per-flow state, which is essential for applying differentiated services.