### PR TITLE
feat: Implement Flow Classification with header fixes

### DIFF
--- a/hqts/include/hqts/core/traffic_shaper.h
+++ b/hqts/include/hqts/core/traffic_shaper.h
@@ -1,15 +1,19 @@
 #ifndef HQTS_CORE_TRAFFIC_SHAPER_H_
 #define HQTS_CORE_TRAFFIC_SHAPER_H_
 
-#include "hqts/core/flow_context.h"        // For FlowContext, FlowTable, core::FlowId
+// #include "hqts/core/flow_context.h"        // REMOVED - Will be forward-declared
 #include "hqts/core/shaping_policy.h"      // Includes TokenBucket
 #include "hqts/policy/policy_tree.h"       // For PolicyTree
 #include "hqts/scheduler/packet_descriptor.h"// For PacketDescriptor
-#include "hqts/dataplane/flow_classifier.h"// For FlowClassifier
+#include "hqts/dataplane/flow_classifier.h"// For FlowClassifier (already forward-declares FlowTable)
 #include "hqts/dataplane/flow_identifier.h"// For FiveTuple
 
 #include <memory>
 #include <map>    // For potential scheduler_map_ if used later
+
+// Forward declaration for core::FlowTable
+// Note: flow_classifier.h might also forward-declare it. Redundant is okay.
+namespace hqts { namespace core { class FlowTable; } }
 
 namespace hqts {
 namespace core {

--- a/hqts/include/hqts/dataplane/flow_classifier.h
+++ b/hqts/include/hqts/dataplane/flow_classifier.h
@@ -2,13 +2,18 @@
 #define HQTS_DATAPLANE_FLOW_CLASSIFIER_H_
 
 #include "hqts/dataplane/flow_identifier.h" // For FiveTuple, FlowKey
-#include "hqts/core/flow_context.h"        // For core::FlowId, FlowContext, core::FlowTable
 #include "hqts/policy/policy_types.h"      // For policy::PolicyId
-// #include "hqts/scheduler/packet_descriptor.h" // Not directly needed if FiveTuple is passed
-
+#include <cstdint>                         // For std::uint64_t
 #include <unordered_map>
 #include <mutex>    // For std::mutex and std::lock_guard
 #include <memory>   // For std::shared_ptr (not used here, but often in similar contexts)
+
+// Forward declaration for FlowTable
+namespace hqts { namespace core { class FlowTable; } }
+
+// Ensure core::FlowId is defined for use in this header
+// (Matches the definition in hqts/core/flow_context.h)
+namespace hqts { namespace core { using FlowId = std::uint64_t; } }
 
 namespace hqts {
 namespace dataplane {

--- a/hqts/src/dataplane/flow_classifier.cpp
+++ b/hqts/src/dataplane/flow_classifier.cpp
@@ -1,4 +1,5 @@
 #include "hqts/dataplane/flow_classifier.h"
+#include "hqts/core/flow_context.h" // Ensure full definitions for FlowTable and FlowContext
 #include <stdexcept> // For std::runtime_error (though not used in current version)
 #include <string>    // For std::to_string (not used in current version)
 


### PR DESCRIPTION
This commit introduces packet classification capabilities and integrates them with the TrafficShaper. It also includes critical header adjustments to resolve compilation errors related to type definitions and include order.

Key components and changes:
1.  Flow Identification Structures (`dataplane/flow_identifier.h`):
    - Defined `FiveTuple` struct and `FlowKey` type alias.
    - Provided `std::hash<FiveTuple>` specialization.

2.  Flow Classifier (`dataplane/flow_classifier.h/cpp`):
    - Implemented `FlowClassifier` to map `FiveTuple` to `core::FlowId` and manage `FlowContext` creation with a default policy.
    - Includes thread-safe operations.
    - Fix: `flow_classifier.h` now uses a forward declaration for `core::FlowTable` and includes `<cstdint>` for `std::uint64_t` (used as `core::FlowId` alias internally in header). The full include of `core/flow_context.h` is deferred to `flow_classifier.cpp`.

3.  Integration with TrafficShaper (`core/traffic_shaper.h/cpp`):
    - `TrafficShaper` now uses `FlowClassifier` to get/create `FlowContext` based on `FiveTuple`.
    - `process_packet()` signature updated to take `FiveTuple`.
    - Fix: `traffic_shaper.h` now uses a forward declaration for `core::FlowTable`. The full include of `core/flow_context.h` is deferred to `traffic_shaper.cpp`.

4.  Unit Tests:
    - Added tests for `FlowClassifier` (`tests/unit/dataplane/test_flow_classifier.cpp`).
    - Updated `TrafficShaper` tests (`tests/unit/core/test_traffic_shaper.cpp`) for API changes.

5.  CMake Updates:
    - `src/CMakeLists.txt` and `tests/CMakeLists.txt` updated for new files.

These changes provide a foundational flow classification mechanism and resolve previous compilation issues by correctly managing header dependencies and forward declarations.