### PR TITLE
Okay, I've implemented the flow classification feature and fixed all …

### DIFF
--- a/hqts/tests/unit/core/test_traffic_shaper.cpp
+++ b/hqts/tests/unit/core/test_traffic_shaper.cpp
@@ -146,9 +146,12 @@ TEST_F(TrafficShaperTest, ProcessPacketRedAndAllow) {
     dataplane::FiveTuple tuple_gyr(1,2,3,4,6);
     set_policy_for_flow(tuple_gyr, POLICY_ID_GREEN_YELLOW_RED); // Policy 1: drop_on_red = false
 
-    ASSERT_TRUE(shaper_->process_packet(createShaperTestPacket(0, 1000), tuple_gyr));
-    ASSERT_TRUE(shaper_->process_packet(createShaperTestPacket(0, 1000), tuple_gyr));
-    ASSERT_TRUE(shaper_->process_packet(createShaperTestPacket(0, 1000), tuple_gyr));
+    scheduler::PacketDescriptor p_allow1 = createShaperTestPacket(0, 1000);
+    ASSERT_TRUE(shaper_->process_packet(p_allow1, tuple_gyr));
+    scheduler::PacketDescriptor p_allow2 = createShaperTestPacket(0, 1000);
+    ASSERT_TRUE(shaper_->process_packet(p_allow2, tuple_gyr));
+    scheduler::PacketDescriptor p_allow3 = createShaperTestPacket(0, 1000);
+    ASSERT_TRUE(shaper_->process_packet(p_allow3, tuple_gyr));
 
     scheduler::PacketDescriptor packet4 = createShaperTestPacket(0, 500);
     bool should_enqueue_p4 = shaper_->process_packet(packet4, tuple_gyr);
@@ -162,8 +165,10 @@ TEST_F(TrafficShaperTest, ProcessPacketRedAndDrop) {
     dataplane::FiveTuple tuple_drop_r(3,4,5,6,6);
     set_policy_for_flow(tuple_drop_r, POLICY_ID_DROP_RED); // Policy 2: drop_on_red = true
 
-    ASSERT_TRUE(shaper_->process_packet(createShaperTestPacket(0, 800), tuple_drop_r));
-    ASSERT_TRUE(shaper_->process_packet(createShaperTestPacket(0, 800), tuple_drop_r));
+    scheduler::PacketDescriptor p_drop1 = createShaperTestPacket(0, 800);
+    ASSERT_TRUE(shaper_->process_packet(p_drop1, tuple_drop_r));
+    scheduler::PacketDescriptor p_drop2 = createShaperTestPacket(0, 800);
+    ASSERT_TRUE(shaper_->process_packet(p_drop2, tuple_drop_r));
 
     scheduler::PacketDescriptor packet3 = createShaperTestPacket(0, 800);
     bool should_enqueue_p3 = shaper_->process_packet(packet3, tuple_drop_r);


### PR DESCRIPTION
…related header and test issues.

This update adds packet classification capabilities, integrates them with the TrafficShaper, and includes several important corrections to header include structures and test files. This should resolve all known compilation errors and test failures for these components.

Here's a summary of the key changes:

1.  **Flow Identification Structures** (`dataplane/flow_identifier.h`):
    *   I defined the `FiveTuple` struct and `FlowKey` type alias.
    *   I also provided a `std::hash<FiveTuple>` specialization.

2.  **`core::FlowTable` Definition** (`dataplane/flow_table.h`):
    *   I've centralized the definition of `core::FlowTable`.

3.  **Flow Classifier** (`dataplane/flow_classifier.h/cpp`):
    *   I implemented `FlowClassifier` to map `FiveTuple` to `core::FlowId` and manage `FlowContext` creation.
    *   I also corrected header includes for `core::FlowTable` and `core::FlowId`.

4.  **Integration with TrafficShaper** (`core/traffic_shaper.h/cpp`):
    *   The `TrafficShaper` now uses the `FlowClassifier`.
    *   I corrected header includes for `core::FlowTable` here as well.

5.  **Unit Tests**:
    *   I added tests for `FlowClassifier` (`tests/unit/dataplane/test_flow_classifier.cpp`).
    *   I updated the `TrafficShaper` tests (`tests/unit/core/test_traffic_shaper.cpp`).
        *   Specifically, I resolved rvalue reference errors by using local lvalue `PacketDescriptor` variables when calling `TrafficShaper::process_packet`.
    *   I also corrected `test_flow_table.cpp` includes and type usage for `core::FlowTable`.

6.  **CMake Updates**:
    *   I updated `src/CMakeLists.txt` and `tests/CMakeLists.txt` to reflect the new and modified files.

All known compilation issues and test failures related to flow classification and TrafficShaper integration have been addressed.