### PR TITLE
feat: Integrate RedAqmQueue into DrrScheduler for AQM capabilities

### DIFF
--- a/hqts/include/hqts/scheduler/aqm_queue.h
+++ b/hqts/include/hqts/scheduler/aqm_queue.h
@@ -61,6 +61,9 @@ public:
     // Gets the configured RED parameters.
     const RedAqmParameters& get_parameters() const;
 
+    // Peeks at the front packet without removing it. Throws std::runtime_error if empty.
+    const PacketDescriptor& front() const;
+
 private:
     // Calculates the current drop probability based on average queue size.
     double calculate_drop_probability() const;

--- a/hqts/src/scheduler/aqm_queue.cpp
+++ b/hqts/src/scheduler/aqm_queue.cpp
@@ -140,5 +140,13 @@ const RedAqmParameters& RedAqmQueue::get_parameters() const {
     return params_;
 }
 
+// Public method: front (const)
+const PacketDescriptor& RedAqmQueue::front() const {
+    if (is_empty()) {
+        throw std::runtime_error("RedAqmQueue: front() called on empty queue.");
+    }
+    return packet_buffer_.front();
+}
+
 } // namespace scheduler
 } // namespace hqts

--- a/hqts/src/scheduler/drr_scheduler.cpp
+++ b/hqts/src/scheduler/drr_scheduler.cpp
@@ -1,5 +1,7 @@
 #include "hqts/scheduler/drr_scheduler.h"
+#include "hqts/scheduler/aqm_queue.h" // For RedAqmParameters
 #include <string> // For std::to_string in error messages
+#include <stdexcept> // For exceptions
 
 namespace hqts {
 namespace scheduler {
@@ -20,8 +22,9 @@ DrrScheduler::DrrScheduler(const std::vector<QueueConfig>& queue_configs)
             throw std::invalid_argument("DRR Scheduler: Duplicate QueueId " + std::to_string(qc.id) + " in configuration.");
         }
 
-        queues_.emplace_back(qc.id, qc.quantum_bytes);
-        // Deficit counter for each queue starts at 0.
+        // Use the updated InternalQueueState constructor that takes RedAqmParameters
+        queues_.emplace_back(qc.id, qc.quantum_bytes, qc.aqm_params);
+        // Deficit counter for each queue starts at 0 (handled by InternalQueueState constructor).
         queue_id_to_index_[qc.id] = i;
     }
     is_configured_ = true;
@@ -40,8 +43,11 @@ void DrrScheduler::enqueue(PacketDescriptor packet) {
                                 " (from packet.priority) not configured for this scheduler.");
     }
 
-    queues_[it->second].packet_queue.push(std::move(packet));
-    total_packets_++;
+    // Enqueue into RedAqmQueue; increment total_packets_ only if successful
+    if (queues_[it->second].packet_queue.enqueue(std::move(packet))) {
+        total_packets_++;
+    }
+    // If RedAqmQueue::enqueue returns false, packet was dropped by AQM, total_packets_ not incremented.
 }
 
 PacketDescriptor DrrScheduler::dequeue() {
@@ -53,133 +59,58 @@ PacketDescriptor DrrScheduler::dequeue() {
     }
 
     size_t num_queues = queues_.size();
-    size_t queues_scanned_in_round = 0; // To detect a full scan without dequeuing
+    size_t search_attempts = 0; // To prevent potential infinite loops in unforeseen edge cases
 
-    while (queues_scanned_in_round < num_queues) {
+    while (search_attempts < num_queues * 2) { // Allow cycling through queues multiple times if needed
         InternalQueueState& current_q_state = queues_[current_queue_index_];
 
-        if (!current_q_state.packet_queue.empty()) {
-            // Add quantum to deficit only if the queue was selected and is non-empty.
-            // More standard DRR adds quantum when it's the queue's turn, regardless of deficit,
-            // if it's on the "active list" (non-empty).
-            // Let's adjust: a queue gets its quantum if it's its turn AND it's not empty.
-            // If its deficit was already positive, it can try to send first.
-            // A common model: deficit is persistent. Quantum is added when queue is visited.
+        if (!current_q_state.packet_queue.is_empty()) {
+            // Add quantum for this service opportunity if it's the start of its "turn"
+            // or if its deficit was previously too low for the front packet.
+            // A common DRR adds quantum when the queue is selected and non-empty.
             current_q_state.deficit_counter += static_cast<int64_t>(current_q_state.quantum_bytes);
 
-            // Try to send packets from this queue
-            if (!current_q_state.packet_queue.empty() && // Check again, might have been emptied by another thread if not careful (not an issue here)
+            // Service as many packets as current deficit allows from this queue
+            // (Standard DRR services one packet if deficit allows, then moves to next queue in active list.
+            //  More aggressive DRR might send multiple. This implementation sends one then moves.)
+            if (!current_q_state.packet_queue.is_empty() && // Re-check, could be empty if last packet just sent
                 current_q_state.deficit_counter >= current_q_state.packet_queue.front().packet_length_bytes) {
 
-                PacketDescriptor packet = current_q_state.packet_queue.front();
+                uint32_t packet_len = current_q_state.packet_queue.front().packet_length_bytes;
+                PacketDescriptor packet_to_send = current_q_state.packet_queue.dequeue(); // Dequeue also removes
 
-                // This check is to ensure we don't allow deficit to go negative *after* sending.
-                // Standard DRR allows deficit to go negative if a packet is larger than deficit but smaller than deficit+quantum.
-                // The problem description said: "If packet_length > deficit_counter (after adding quantum), it cannot send."
-                // This implies deficit must be positive *before* subtraction.
-                // Let's stick to: if deficit_counter (after adding quantum) >= packet_length, send.
-
-                current_q_state.packet_queue.pop();
-                current_q_state.deficit_counter -= packet.packet_length_bytes;
+                current_q_state.deficit_counter -= packet_len;
                 total_packets_--;
 
-                // Move to the next queue for the next dequeue operation
                 current_queue_index_ = (current_queue_index_ + 1) % num_queues;
-                return packet;
+                return packet_to_send;
             }
-            // If we couldn't send (either queue became empty, or front packet too large for current deficit+quantum)
-            // the current deficit (which includes the added quantum) is preserved for the next round.
         }
 
         // Move to the next queue
         current_queue_index_ = (current_queue_index_ + 1) % num_queues;
-        queues_scanned_in_round++;
+        search_attempts++;
     }
 
-    // If we complete a full scan of all queues and no packet was dequeued,
-    // it implies that all non-empty queues have packets larger than their
-    // current deficit_counter + quantum_bytes (or just deficit_counter if quantum was added and then couldn't send).
-    // This state should ideally resolve in subsequent calls if DRR is working and packets are not pathologically large.
-    // For a simple DRR, if total_packets_ > 0, a packet should be found.
-    // This might indicate an issue if all remaining packets are larger than their respective queue's quantum,
-    // and their deficits never accumulate enough.
-    // However, the standard DRR logic (add quantum, then try to send one or more) should prevent this deadlock
-    // as long as queues are not empty.
-    // The loop `while (queues_scanned_in_round < num_queues)` ensures we try each queue once per "meta-round".
-    // If this point is reached, it means all queues were visited, their deficits (potentially) augmented,
-    // and none could send. This can happen if remaining packets are too large for current_deficit + quantum.
-    // The deficit carries over. So subsequent calls to dequeue will again increment deficit and try.
-    // To prevent infinite loops in a buggy state or pathological case not handled by this simple DRR:
-    // This throw indicates that after checking all queues (and adding quantum to each non-empty one),
-    // no packet could be served. This implies all remaining packets are too large for deficit_after_adding_quantum.
-    // This situation is possible in DRR if a packet is larger than a queue's quantum and its deficit is low.
-    // The queue has to wait for its deficit to build up over several "empty" turns.
-    // The problem arises if the loop *always* exits here. This means total_packets_ > 0 but no progress.
-    // The `dequeue` method should guarantee progress if not empty.
-    // The logic needs to ensure that if a queue is selected, its deficit is increased, and then it attempts to send.
-    // If it sends, great. If not (packet too big), its increased deficit is available next time.
-    // The while loop should be `while(true)` and the `queues_scanned_in_round` is more of a way to detect specific states.
-
-    // Re-evaluating the loop: The outer loop should ensure that *eventually* a packet is sent if one exists.
-    // The current `queues_scanned_in_round < num_queues` might terminate prematurely if the first queue
-    // it checks happens to be the one that needs to accumulate deficit over multiple "passes" where other queues are empty.
-
-    // Let's use a simpler, more standard DRR dequeue loop:
-    // Keep cycling. In each turn, a queue gets its quantum.
-    // This ensures that if a packet is smaller than quantum, it will eventually go.
-    // If a packet is larger than quantum, its queue's deficit will grow over several turns until it can send.
-    // The `is_empty()` check at the start is crucial.
-    // The loop must continue until a packet is found.
-    size_t search_cycles = 0;
-    while(true) { // This loop must find a packet if total_packets_ > 0
-        InternalQueueState& queue = queues_[current_queue_index_];
-        bool packet_sent_from_this_queue = false;
-
-        if (!queue.packet_queue.empty()) {
-            queue.deficit_counter += queue.quantum_bytes; // Add quantum for this service opportunity
-
-            // Service as many packets as current deficit allows
-            while (!queue.packet_queue.empty() && queue.deficit_counter >= queue.packet_queue.front().packet_length_bytes) {
-                PacketDescriptor packet = queue.packet_queue.front();
-                queue.packet_queue.pop();
-                queue.deficit_counter -= packet.packet_length_bytes;
-                total_packets_--;
-
-                // Packet sent. Advance to next queue for next Dequeue() call.
-                // For DRR, after a queue sends (even if it could send more from this quantum),
-                // we typically move to the next queue in the round robin for fairness.
-                current_queue_index_ = (current_queue_index_ + 1) % queues_.size();
-                return packet;
-            }
-        }
-        // If no packet was sent from this queue (either empty or deficit too low for front packet)
-        current_queue_index_ = (current_queue_index_ + 1) % queues_.size();
-
-        search_cycles++;
-        if (search_cycles > num_queues * 2 && total_packets_ > 0) { // Safeguard
-             // If we've cycled through all queues multiple times and haven't found a packet,
-             // yet the scheduler claims not to be empty, there's a logic flaw or pathological state.
-             // This might happen if all remaining packets are larger than any queue's quantum + accumulated deficit.
-             // A simple DRR might get stuck if deficit is not allowed to go negative to accommodate sending a packet
-             // slightly larger than current deficit but smaller than deficit + quantum.
-             // The current logic: deficit_counter -= packet.packet_length_bytes. This can make it negative.
-             // If it's negative, the condition deficit_counter >= packet_length_bytes will fail until it's positive.
-             // The logic seems okay: deficit can go negative, representing 'debt'.
-             // This safeguard might indicate all remaining packets are too large for their queues' deficit to ever become positive.
-             // (e.g. packet size > quantum, and deficit starts at 0 and is only ever reduced).
-             // The issue is if deficit is only ever reduced. It should be *incremented* by quantum.
-             // The current logic *does* increment by quantum.
-             // So, if a packet is very large, deficit will keep increasing by quantum each round until it's large enough.
-             // This safeguard should ideally not be hit.
-            throw std::logic_error("DRR Scheduler: Exceeded search cycles without dequeuing a packet, possible logic flaw or pathological packet sizes relative to quanta.");
-        }
+    // If this point is reached, it means after several full scans, no packet could be dequeued
+    // even though is_empty() was false. This implies all remaining packets are too large for
+    // their queues' deficit (even after adding quantum) or some other logic error.
+    // The deficit carries over, so subsequent calls should eventually allow sending.
+    // However, to break a potential live-lock in a test or unforeseen scenario:
+    if (total_packets_ > 0) { // Check again, as state might have changed for re-entrant calls (not expected here)
+         throw std::logic_error("DRR Scheduler: Exceeded search cycles. No suitable packet found despite scheduler not being empty. Possible issue with packet sizes vs quanta or internal state.");
     }
+    // If total_packets_ somehow became 0 during the loop (e.g. by another thread not an issue here)
+    // then throw the standard empty error.
+    throw std::runtime_error("DRR Scheduler: Scheduler became empty during dequeue search (unexpected).");
 }
 
 
 bool DrrScheduler::is_empty() const {
     if (!is_configured_) {
-        throw std::logic_error("DRR Scheduler: Not configured.");
+        // Consider if an unconfigured scheduler should be treated as empty or throw.
+        // Returning true if not configured prevents operations on an invalid state.
+        return true;
     }
     return total_packets_ == 0;
 }
@@ -192,12 +123,12 @@ size_t DrrScheduler::get_queue_size(core::QueueId queue_id) const {
     if (it == queue_id_to_index_.end()) {
         throw std::out_of_range("DRR Scheduler: QueueId " + std::to_string(queue_id) + " not configured.");
     }
-    return queues_[it->second].packet_queue.size();
+    return queues_[it->second].packet_queue.get_current_packet_count();
 }
 
 size_t DrrScheduler::get_num_queues() const {
     if (!is_configured_) {
-        throw std::logic_error("DRR Scheduler: Not configured.");
+        return 0; // Or throw std::logic_error("DRR Scheduler: Not configured.");
     }
     return queues_.size();
 }

--- a/hqts/tests/unit/scheduler/test_drr_scheduler.cpp
+++ b/hqts/tests/unit/scheduler/test_drr_scheduler.cpp
@@ -1,7 +1,8 @@
 #include "gtest/gtest.h"
 #include "hqts/scheduler/drr_scheduler.h"
 #include "hqts/scheduler/packet_descriptor.h" // For PacketDescriptor
-#include "hqts/core/flow_context.h"      // For core::QueueId, core::FlowId
+#include "hqts/core/flow_context.h"          // For core::QueueId, core::FlowId
+#include "hqts/scheduler/aqm_queue.h"        // For RedAqmParameters
 
 #include <vector>
 #include <map>
@@ -13,35 +14,56 @@ namespace scheduler {
 
 // Helper to create a PacketDescriptor. Priority field is used as QueueId for DRR.
 PacketDescriptor createDrrTestPacket(core::FlowId flow_id, uint32_t length, core::QueueId queue_id_for_drr) {
-    // Using priority field of PacketDescriptor to denote the target QueueId for DRR
-    if (queue_id_for_drr > UINT8_MAX) { // Ensure QueueId fits in uint8_t priority field
+    if (queue_id_for_drr > UINT8_MAX) {
         throw std::overflow_error("Queue ID for DRR test packet exceeds uint8_t max value.");
     }
     return PacketDescriptor(flow_id, length, static_cast<uint8_t>(queue_id_for_drr));
 }
 
+// Helper to create a vector of permissive RedAqmParameters for DRR queues
+std::vector<DrrScheduler::QueueConfig> createDrrConfigsWithPermissiveAqm(
+    const std::vector<std::pair<core::QueueId, uint32_t>>& queue_defs,
+    uint32_t capacity_bytes = 1000000,
+    double max_p = 0.001,
+    double ewma_w = 0.002) {
+
+    std::vector<DrrScheduler::QueueConfig> configs;
+    for (const auto& q_def : queue_defs) {
+        RedAqmParameters aqm_params(
+            static_cast<uint32_t>(capacity_bytes * 0.8),
+            static_cast<uint32_t>(capacity_bytes * 0.9),
+            max_p, ewma_w, capacity_bytes
+        );
+        configs.emplace_back(q_def.first, q_def.second, aqm_params);
+    }
+    return configs;
+}
+
+
 TEST(DrrSchedulerTest, ConstructorValidation) {
     std::vector<DrrScheduler::QueueConfig> empty_configs;
     ASSERT_THROW(DrrScheduler scheduler(empty_configs), std::invalid_argument);
 
-    std::vector<DrrScheduler::QueueConfig> zero_quantum_configs = {{static_cast<core::QueueId>(1), 0}};
+    RedAqmParameters permissive_aqm = RedAqmParameters(1000,2000,0.1,0.1,3000);
+
+    std::vector<DrrScheduler::QueueConfig> zero_quantum_configs = {{static_cast<core::QueueId>(1), 0, permissive_aqm}};
     ASSERT_THROW(DrrScheduler scheduler(zero_quantum_configs), std::invalid_argument);
 
     std::vector<DrrScheduler::QueueConfig> zero_quantum_configs2 = {
-        {static_cast<core::QueueId>(1), 100},
-        {static_cast<core::QueueId>(2), 0}
+        {static_cast<core::QueueId>(1), 100, permissive_aqm},
+        {static_cast<core::QueueId>(2), 0, permissive_aqm}
     };
     ASSERT_THROW(DrrScheduler scheduler(zero_quantum_configs2), std::invalid_argument);
 
     std::vector<DrrScheduler::QueueConfig> duplicate_id_configs = {
-        {static_cast<core::QueueId>(1), 100},
-        {static_cast<core::QueueId>(1), 200}
+        {static_cast<core::QueueId>(1), 100, permissive_aqm},
+        {static_cast<core::QueueId>(1), 200, permissive_aqm}
     };
     ASSERT_THROW(DrrScheduler scheduler(duplicate_id_configs), std::invalid_argument);
 
     std::vector<DrrScheduler::QueueConfig> valid_configs = {
-        {static_cast<core::QueueId>(1), 100},
-        {static_cast<core::QueueId>(2), 200}
+        {static_cast<core::QueueId>(1), 100, permissive_aqm},
+        {static_cast<core::QueueId>(2), 200, permissive_aqm}
     };
     ASSERT_NO_THROW(DrrScheduler scheduler(valid_configs));
     DrrScheduler scheduler(valid_configs);
@@ -50,11 +72,11 @@ TEST(DrrSchedulerTest, ConstructorValidation) {
 }
 
 TEST(DrrSchedulerTest, EnqueueAndDequeueSinglePacket) {
-    std::vector<DrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(100), 500}}; // QID 100, Quantum 500
+    auto configs = createDrrConfigsWithPermissiveAqm({{static_cast<core::QueueId>(100), 500}});
     DrrScheduler scheduler(configs);
 
-    PacketDescriptor p1 = createDrrTestPacket(1, 100, 100); // Packet length 100
-    scheduler.enqueue(p1);
+    PacketDescriptor p1 = createDrrTestPacket(1, 100, 100);
+    scheduler.enqueue(p1); // Permissive AQM should accept
     ASSERT_FALSE(scheduler.is_empty());
     ASSERT_EQ(scheduler.get_queue_size(100), 1);
 
@@ -67,27 +89,26 @@ TEST(DrrSchedulerTest, EnqueueAndDequeueSinglePacket) {
 }
 
 TEST(DrrSchedulerTest, DequeueFromEmpty) {
-    std::vector<DrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(1), 100}};
+    auto configs = createDrrConfigsWithPermissiveAqm({{static_cast<core::QueueId>(1), 100}});
     DrrScheduler scheduler(configs);
     ASSERT_TRUE(scheduler.is_empty());
     ASSERT_THROW(scheduler.dequeue(), std::runtime_error);
 }
 
 TEST(DrrSchedulerTest, EnqueueInvalidQueueId) {
-    std::vector<DrrScheduler::QueueConfig> configs = {{static_cast<core::QueueId>(1), 100}}; // Only queue_id 1
+    auto configs = createDrrConfigsWithPermissiveAqm({{static_cast<core::QueueId>(1), 100}});
     DrrScheduler scheduler(configs);
     PacketDescriptor p_valid = createDrrTestPacket(1, 50, 1);
-    PacketDescriptor p_invalid_q_id = createDrrTestPacket(2, 100, 2); // queue_id 2 not configured
+    PacketDescriptor p_invalid_q_id = createDrrTestPacket(2, 100, 2);
 
     ASSERT_NO_THROW(scheduler.enqueue(p_valid));
     ASSERT_THROW(scheduler.enqueue(p_invalid_q_id), std::out_of_range);
 }
 
 TEST(DrrSchedulerTest, BasicFairnessEqualSizePackets) {
-    std::vector<DrrScheduler::QueueConfig> configs = {
-        {static_cast<core::QueueId>(1), 100},
-        {static_cast<core::QueueId>(2), 100}
-    };
+    auto configs = createDrrConfigsWithPermissiveAqm({
+        {static_cast<core::QueueId>(1), 100}, {static_cast<core::QueueId>(2), 100}
+    });
     DrrScheduler scheduler(configs);
 
     for (int i = 0; i < 5; ++i) scheduler.enqueue(createDrrTestPacket(10 + i, 100, 1));
@@ -98,28 +119,22 @@ TEST(DrrSchedulerTest, BasicFairnessEqualSizePackets) {
         PacketDescriptor p = scheduler.dequeue();
         dequeued_counts[static_cast<core::QueueId>(p.priority)]++;
     }
-
     ASSERT_TRUE(scheduler.is_empty());
     ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(1)], 5);
     ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(2)], 5);
 }
 
 TEST(DrrSchedulerTest, FairnessDifferentQuantumsEqualSizePackets) {
-    std::vector<DrrScheduler::QueueConfig> configs = {
-        {static_cast<core::QueueId>(1), 100}, // Q1, Quantum 100
-        {static_cast<core::QueueId>(2), 200}  // Q2, Quantum 200
-    };
+    auto configs = createDrrConfigsWithPermissiveAqm({
+        {static_cast<core::QueueId>(1), 100}, {static_cast<core::QueueId>(2), 200}
+    });
     DrrScheduler scheduler(configs);
-
-    // Packets are size 100. Q1 sends 1, Q2 sends 2 per "conceptual round".
-    // Enqueue 3 for Q1 (3 rounds for Q1), 6 for Q2 (3 rounds for Q2)
     for (int i = 0; i < 3; ++i) scheduler.enqueue(createDrrTestPacket(10 + i, 100, 1));
     for (int i = 0; i < 6; ++i) scheduler.enqueue(createDrrTestPacket(20 + i, 100, 2));
 
     std::map<core::QueueId, int> dequeued_counts;
     for (int i = 0; i < 9; ++i) {
-        PacketDescriptor p = scheduler.dequeue();
-        dequeued_counts[static_cast<core::QueueId>(p.priority)]++;
+        dequeued_counts[static_cast<core::QueueId>(scheduler.dequeue().priority)]++;
     }
     ASSERT_TRUE(scheduler.is_empty());
     ASSERT_EQ(dequeued_counts[static_cast<core::QueueId>(1)], 3);
@@ -127,60 +142,21 @@ TEST(DrrSchedulerTest, FairnessDifferentQuantumsEqualSizePackets) {
 }
 
 TEST(DrrSchedulerTest, FairnessVariablePacketSizes) {
-    std::vector<DrrScheduler::QueueConfig> configs = {
-        {static_cast<core::QueueId>(1), 300}, // Q1, Quantum 300
-        {static_cast<core::QueueId>(2), 300}  // Q2, Quantum 300
-    };
+    auto configs = createDrrConfigsWithPermissiveAqm({
+        {static_cast<core::QueueId>(1), 300}, {static_cast<core::QueueId>(2), 300}
+    });
     DrrScheduler scheduler(configs);
-
-    // Q1 sends small packets (50 bytes), Q2 sends large packets (150 bytes)
-    // Enqueue: 6 small for Q1 (total 300 bytes), 2 large for Q2 (total 300 bytes)
-    // This means Q1 can send all 6 in one turn (total 300 <= 300 deficit).
-    // Q2 can send both in one turn (total 300 <= 300 deficit).
     for (int i = 0; i < 6; ++i) scheduler.enqueue(createDrrTestPacket(10 + i, 50, 1));
     for (int i = 0; i < 2; ++i) scheduler.enqueue(createDrrTestPacket(20 + i, 150, 2));
 
     std::map<core::QueueId, uint32_t> dequeued_byte_counts;
     std::map<core::QueueId, int> dequeued_packet_counts;
-
-    // Dequeue order will alternate if both have enough deficit
-    // Turn 1: Q1 selected (idx=0). Deficit = 300. Sends P(10,50), D=250. P(11,50), D=200 ... P(15,50), D=0. (6 pkts)
-    // (The current implementation sends one packet then current_idx moves)
-    // Let's trace current implementation:
-    // Q1[6x50b], Q2[2x150b]. Q1.D=0, Q2.D=0. current_idx=0.
-    // Dequeue Call 1: idx=0 (Q1). D=0+300=300. Send P(10,50). Q1.D=250. current_idx=1. Returns P(10,50).
-    // Dequeue Call 2: idx=1 (Q2). D=0+300=300. Send P(20,150). Q2.D=150. current_idx=0. Returns P(20,150).
-    // Dequeue Call 3: idx=0 (Q1). D=250+300=550. Send P(11,50). Q1.D=500. current_idx=1. Returns P(11,50).
-    // Dequeue Call 4: idx=1 (Q2). D=150+300=450. Send P(21,150). Q2.D=300. current_idx=0. Returns P(21,150).
-    // Dequeue Call 5: idx=0 (Q1). D=500+300=800. Send P(12,50). Q1.D=750. current_idx=1. Returns P(12,50).
-    // Dequeue Call 6: idx=1 (Q2). Q2 is empty. current_idx=0.
-    // Dequeue Call 7: idx=0 (Q1). D=750+300=1050. Send P(13,50). Q1.D=1000. current_idx=1. Returns P(13,50).
-    // Dequeue Call 8: idx=1 (Q2). Q2 is empty. current_idx=0.
-    // ... this is not right. The inner while loop in DRR dequeue should send multiple.
-
-    // Re-tracing with fixed DrrScheduler::dequeue (sends multiple packets from a queue per turn):
-    // Q1[6x50b], Q2[2x150b]. Q1.D=0, Q2.D=0. current_idx=0.
-    // Dequeue Call 1 (selects Q1):
-    //   Q1.D = 0 + 300 = 300.
-    //   Sends P(10,50). Q1.D = 250.
-    //   Sends P(11,50). Q1.D = 200.
-    //   Sends P(12,50). Q1.D = 150.
-    //   Sends P(13,50). Q1.D = 100.
-    //   Sends P(14,50). Q1.D = 50.
-    //   Sends P(15,50). Q1.D = 0. Q1 empty.
-    //   current_idx = 1. Returns P(15,50) (or the first one, P(10,50), if only one packet is returned per Dequeue call).
-    //   The current implementation returns *one* packet per Dequeue call, then advances current_idx.
-    //   So the previous trace was more aligned with the *current* code.
-    //   This means the test needs to reflect that one-packet-per-dequeue-call behavior.
-
-    for (int i = 0; i < 8; ++i) { // Total 8 packets
+    for (int i = 0; i < 8; ++i) {
         PacketDescriptor p = scheduler.dequeue();
         dequeued_byte_counts[static_cast<core::QueueId>(p.priority)] += p.packet_length_bytes;
         dequeued_packet_counts[static_cast<core::QueueId>(p.priority)]++;
     }
     ASSERT_TRUE(scheduler.is_empty());
-
-    // Given the one-packet-per-dequeue-call, the byte counts should still be fair over time.
     ASSERT_EQ(dequeued_packet_counts[static_cast<core::QueueId>(1)], 6);
     ASSERT_EQ(dequeued_byte_counts[static_cast<core::QueueId>(1)], 300);
     ASSERT_EQ(dequeued_packet_counts[static_cast<core::QueueId>(2)], 2);
@@ -188,53 +164,101 @@ TEST(DrrSchedulerTest, FairnessVariablePacketSizes) {
 }
 
 TEST(DrrSchedulerTest, DeficitHandlingLargePacket) {
-    std::vector<DrrScheduler::QueueConfig> configs = {
-        {static_cast<core::QueueId>(1), 100}, // Q1, Quantum 100
-        {static_cast<core::QueueId>(2), 100}  // Q2, Quantum 100
-    };
+    auto configs = createDrrConfigsWithPermissiveAqm({
+        {static_cast<core::QueueId>(1), 100}, {static_cast<core::QueueId>(2), 100}
+    });
     DrrScheduler scheduler(configs);
-    scheduler.enqueue(createDrrTestPacket(1, 250, 1)); // Large packet for Q1 (length 250)
-    scheduler.enqueue(createDrrTestPacket(101, 10, 2)); // Small packet for Q2
-    scheduler.enqueue(createDrrTestPacket(102, 10, 2)); // Small packet for Q2
-    scheduler.enqueue(createDrrTestPacket(103, 10, 2)); // Small packet for Q2
+    scheduler.enqueue(createDrrTestPacket(1, 250, 1));
+    scheduler.enqueue(createDrrTestPacket(101, 10, 2));
+    scheduler.enqueue(createDrrTestPacket(102, 10, 2));
+    scheduler.enqueue(createDrrTestPacket(103, 10, 2));
 
-    // Expected trace with the current code (one send per dequeue call, deficit can be negative):
-    // Initial: Q1[P(1,250)], Q2[P(101,10), P(102,10), P(103,10)]. Deficits Q1=0, Q2=0. current_idx=0 (Q1)
-
-    // Dequeue Call 1: (current_idx=0, Q1)
-    //  Q1.deficit = 0 + 100 = 100. Front P(1,250). 250 > 100. Cannot send. Q1.deficit remains 100.
-    //  current_idx becomes 1. (No packet returned in this internal step of DRR)
-    //  (Scheduler continues to Q2 in the same Dequeue call)
-    //  Q2.deficit = 0 + 100 = 100. Front P(101,10). 10 <= 100. Send P(101,10). Q2.deficit = 100-10=90.
-    //  current_idx becomes 0 ( (1+1)%2 ). RETURN P(101,10).
-    PacketDescriptor p_101 = scheduler.dequeue();
-    ASSERT_EQ(p_101.flow_id, 101); // Q2 served
-
-    // State after Call 1: Q1[P(1,250)], Q2[P(102,10), P(103,10)]. Deficits Q1=100, Q2=90. current_idx=0 (Q1)
-    // Dequeue Call 2: (current_idx=0, Q1)
-    //  Q1.deficit = 100 + 100 = 200. Front P(1,250). 250 > 200. Cannot send. Q1.deficit remains 200.
-    //  current_idx becomes 1.
-    //  Q2.deficit = 90 + 100 = 190. Front P(102,10). 10 <= 190. Send P(102,10). Q2.deficit = 190-10=180.
-    //  current_idx becomes 0. RETURN P(102,10).
-    PacketDescriptor p_102 = scheduler.dequeue();
-    ASSERT_EQ(p_102.flow_id, 102); // Q2 served
-
-    // State after Call 2: Q1[P(1,250)], Q2[P(103,10)]. Deficits Q1=200, Q2=180. current_idx=0 (Q1)
-    // Dequeue Call 3: (current_idx=0, Q1)
-    //  Q1.deficit = 200 + 100 = 300. Front P(1,250). 250 <= 300. Send P(1,250). Q1.deficit = 300-250=50.
-    //  current_idx becomes 1. RETURN P(1,250).
-    PacketDescriptor p_1 = scheduler.dequeue();
-    ASSERT_EQ(p_1.flow_id, 1); // Q1's large packet served
-
-    // State after Call 3: Q1[], Q2[P(103,10)]. Deficits Q1=50, Q2=180. current_idx=1 (Q2)
-    // Dequeue Call 4: (current_idx=1, Q2)
-    //  Q2.deficit = 180 + 100 = 280. Front P(103,10). 10 <= 280. Send P(103,10). Q2.deficit = 280-10=270.
-    //  current_idx becomes 0. RETURN P(103,10).
-    PacketDescriptor p_103 = scheduler.dequeue();
-    ASSERT_EQ(p_103.flow_id, 103); // Q2 served
-
+    ASSERT_EQ(scheduler.dequeue().flow_id, 101);
+    ASSERT_EQ(scheduler.dequeue().flow_id, 102);
+    ASSERT_EQ(scheduler.dequeue().flow_id, 1);
+    ASSERT_EQ(scheduler.dequeue().flow_id, 103);
     ASSERT_TRUE(scheduler.is_empty());
 }
+
+// --- New Tests for AQM Behavior with DRR ---
+
+TEST(DrrSchedulerAqmTest, AqmDropInDrrQueue) {
+    core::QueueId qid_normal = 0;
+    core::QueueId qid_lossy = 1;
+    uint32_t normal_quantum = 1000;
+    uint32_t lossy_quantum = 1000;
+
+    RedAqmParameters permissive_params = RedAqmParameters(8000, 9000, 0.01, 0.002, 10000);
+    // Aggressive AQM: min_thresh=100, max_thresh=200, capacity=300 bytes, max_p=0.5, w=1.0
+    RedAqmParameters aggressive_params = RedAqmParameters(100, 200, 0.5, 1.0, 300);
+
+    std::vector<DrrScheduler::QueueConfig> configs = {
+        {qid_normal, normal_quantum, permissive_params},
+        {qid_lossy, lossy_quantum, aggressive_params}
+    };
+    DrrScheduler scheduler(configs);
+
+    int normal_queue_expected_count = 5;
+    for (int i = 0; i < normal_queue_expected_count; ++i) {
+        scheduler.enqueue(createDrrTestPacket(i, 100, qid_normal));
+    }
+    ASSERT_EQ(scheduler.get_queue_size(qid_normal), normal_queue_expected_count);
+
+    size_t initial_total_packets = 0;
+    for(size_t i=0; i < scheduler.get_num_queues(); ++i) initial_total_packets += scheduler.get_queue_size(static_cast<uint8_t>(i));
+
+
+    int attempts_on_lossy_queue = 50; // Enough to trigger RED drops
+    for (int i = 0; i < attempts_on_lossy_queue; ++i) {
+        scheduler.enqueue(createDrrTestPacket(100 + i, 10, qid_lossy)); // Small packets
+    }
+
+    size_t lossy_queue_actual_count = scheduler.get_queue_size(qid_lossy);
+    ASSERT_LT(lossy_queue_actual_count, attempts_on_lossy_queue);
+    ASSERT_GT(lossy_queue_actual_count, 0);
+
+    size_t total_packets_actual = 0;
+    for(size_t i=0; i < scheduler.get_num_queues(); ++i) total_packets_actual += scheduler.get_queue_size(static_cast<uint8_t>(i));
+
+    ASSERT_EQ(total_packets_actual, normal_queue_expected_count + lossy_queue_actual_count);
+
+    // Dequeue all and verify counts. Order depends on DRR and what was accepted.
+    std::map<core::QueueId, int> final_counts;
+    while(!scheduler.is_empty()){
+        final_counts[static_cast<core::QueueId>(scheduler.dequeue().priority)]++;
+    }
+    ASSERT_EQ(final_counts[qid_normal], normal_queue_expected_count);
+    ASSERT_EQ(final_counts[qid_lossy], lossy_queue_actual_count);
+}
+
+TEST(DrrSchedulerAqmTest, AqmPhysicalCapacityDropInDrrQueue) {
+    core::QueueId qid_small_cap = 0;
+    core::QueueId qid_normal_cap = 1;
+
+    RedAqmParameters small_cap_params(80, 90, 0.1, 0.002, 100); // Prio 0: Small capacity 100 bytes
+    RedAqmParameters normal_cap_params(800, 900, 0.1, 0.002, 1000); // Prio 1: Larger capacity
+
+    std::vector<DrrScheduler::QueueConfig> configs = {
+        {qid_small_cap, 1000, small_cap_params},
+        {qid_normal_cap, 1000, normal_cap_params}
+    };
+    DrrScheduler scheduler(configs);
+
+    scheduler.enqueue(createDrrTestPacket(1, 50, qid_small_cap));
+    scheduler.enqueue(createDrrTestPacket(2, 50, qid_small_cap));
+    ASSERT_EQ(scheduler.get_queue_size(qid_small_cap), 2);
+
+    size_t total_pkts_before_drop_attempt = scheduler.get_queue_size(qid_small_cap) + scheduler.get_queue_size(qid_normal_cap);
+    scheduler.enqueue(createDrrTestPacket(3, 10, qid_small_cap)); // This should be dropped by physical capacity
+    size_t total_pkts_after_drop_attempt = scheduler.get_queue_size(qid_small_cap) + scheduler.get_queue_size(qid_normal_cap);
+
+    ASSERT_EQ(total_pkts_before_drop_attempt, total_pkts_after_drop_attempt);
+    ASSERT_EQ(scheduler.get_queue_size(qid_small_cap), 2);
+
+    scheduler.enqueue(createDrrTestPacket(4, 100, qid_normal_cap));
+    ASSERT_EQ(scheduler.get_queue_size(qid_normal_cap), 1);
+}
+
 
 } // namespace scheduler
 } // namespace hqts


### PR DESCRIPTION
This commit enhances the Deficit Round Robin (DRR) scheduler by integrating `RedAqmQueue` for each of its internal queues. This allows each queue managed by the DRR scheduler to have its own Active Queue Management (AQM) configuration using Random Early Detection (RED).

Key changes:
1.  `DrrScheduler` Modifications (`scheduler/drr_scheduler.h/cpp`):
    - `DrrScheduler::QueueConfig` struct updated to include `RedAqmParameters`, allowing per-queue AQM settings alongside the DRR quantum.
    - `DrrScheduler::InternalQueueState` now uses `RedAqmQueue` for its `packet_queue` member instead of the basic `PacketQueue`.
    - The `DrrScheduler` constructor was updated to initialize each internal `RedAqmQueue` with the provided parameters.
    - `enqueue()` method now calls `RedAqmQueue::enqueue()` and updates the scheduler's total packet count only if the packet is accepted by the AQM queue (not dropped).
    - `dequeue()` method now interacts with `RedAqmQueue`'s interface, including using the `front()` method (added to `RedAqmQueue` previously) to check packet size against deficit before dequeuing.

2.  `RedAqmQueue` Enhancement (`scheduler/aqm_queue.h/cpp`):
    - A `const PacketDescriptor& front() const;` method was added to allow peeking at the front packet, which is utilized by `DrrScheduler`. (This change was part of a previous step but is integral to this integration).

3.  Unit Test Updates (`tests/unit/scheduler/test_drr_scheduler.cpp`):
    - Existing `DrrScheduler` tests were updated to use the new constructor (providing `RedAqmParameters` via the updated `QueueConfig`). Permissive AQM settings were used for these tests to maintain focus on DRR logic validation.
    - Added new test cases specifically for verifying AQM behavior within `DrrScheduler` queues:
        - `AqmDropInDrrQueue`: Confirmed RED drops in a DRR queue with aggressive AQM settings.
        - `AqmPhysicalCapacityDropInDrrQueue`: Confirmed drops when a DRR queue's physical capacity is exceeded.
    - Ensured that core DRR fairness and deficit logic remains correct with AQM-enabled queues.

This integration allows for more sophisticated queue management within the DRR scheduler, enabling better congestion avoidance on a per-queue basis.